### PR TITLE
Introduce manifest schema and example file

### DIFF
--- a/docs/manifest-example.json
+++ b/docs/manifest-example.json
@@ -1,6 +1,7 @@
 {
     "name": "High school video distribution list",
     "date": "2025-10-10",
+    "version": "v1.0.0",
     "sections": [
         {
             "name": "Equations",

--- a/docs/manifest-schema.json
+++ b/docs/manifest-schema.json
@@ -55,6 +55,11 @@
             "description": "The name of the current content distribution schema. e.g.: \"High School distribution list\".",
             "type": "string"
         },
+        "version": {
+            "description": "The version of the manifest file. Different versions use different schemas.",
+            "type": "string",
+            "pattern": "v[0-9]+\\.[0-9]+\\.[0-9]+"
+        },
         "date": {
             "description": "Date of deployment of the manifest.",
             "type": "string",


### PR DESCRIPTION
This PR introduces the initial version of the manifest schema and an example version. For the time being, this information is not used in any part of the project, and it is rather simply an interface definition that needs to be used in the future.

The schema follows the format defined in https://json-schema.org/draft/2020-12/json-schema-core