### PR TITLE
Stream video data instead of loading the entire file into memory

### DIFF
--- a/vds-server/src/api/user.rs
+++ b/vds-server/src/api/user.rs
@@ -113,7 +113,7 @@ async fn get_content(api_data: web::Data<ApiData>, id: web::Path<String>) -> imp
         loop {
             // Note we are using a new bytes instance each time on purpose. We could have used
             // `split()` to get the current bytes out and reuse the instance. However, that makes
-            // the bytes turne into a shared instance, which only releases the bytes once all
+            // the bytes turn into a shared instance, which only releases the bytes once all
             // references to each of the chunks are dropped.
             //
             // This would not meet the intent of this code, which is to reduce the memory footprint


### PR DESCRIPTION
This reduces very significantly the memory footprint required by the VDS. Instead of holding the entire file in memory, we only hold up to 4kB of data for the next chunk. This has shown to keep a stable 2 MB of memory usage on the Raspberry Pi 4 with 1 GB of RAM, being well under any worrying levels.

Closes #26