### PR TITLE
Check that selected video is actually downloaded and hide video player if not

### DIFF
--- a/vds-site/src/pages/dashboard.rs
+++ b/vds-site/src/pages/dashboard.rs
@@ -68,15 +68,15 @@ pub fn playlists_list() -> Html {
         }
     } else {
         html! {
-                <div class="playlist-list list">
-                {
-                    sections.iter().map(|section| {
-                        let num_videos = section.content.len();
-                        let first_video_id = section.content.first().map(|v| v.id.clone());
-                        html! { <PlaylistCard playlist_name={section.name.clone()} num_videos={num_videos} first_video_id={first_video_id} /> }
-                    }).collect::<Html>()
-                }
-                </div>
+            <div class="playlist-list list">
+            {
+                sections.iter().map(|section| {
+                    let num_videos = section.content.len();
+                    let first_video_id = section.content.first().map(|v| v.id.clone());
+                    html! { <PlaylistCard playlist_name={section.name.clone()} num_videos={num_videos} first_video_id={first_video_id} /> }
+                }).collect::<Html>()
+            }
+            </div>
         }
     }
 }


### PR DESCRIPTION
I decided against passing the video ID as an optional (as suggested in the issue), since the playlist name is actually derived from the video ID and without it there is nothing to meaningfully show. Instead the video ID is always passed. However, the download status of the video is considered and if it is not downloaded, the video is considered inactive, which hides the video player.

Fixes #31 