### PR TITLE
Fix mobile landscape support

### DIFF
--- a/vds-site/index.scss
+++ b/vds-site/index.scss
@@ -201,6 +201,7 @@ h2 {
   .video-list {
     display: flex;
     flex-direction: column;
+    min-height: 200px;
 
     .card {
       margin: 4px 0;


### PR DESCRIPTION
Because the minimum size of the video-list was not specified, it defaulted to a size that was way too small to be usable, while the inner content was still scrollable, the view into the content was too small.

This commit fixes the problem by specifying a sensible minimum size that covers approximately 2.5 cards in the list (the .5 is intentional to indicate to the user that there is more content).

Fixes #37 