### PR TITLE
Provisioning skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -273,15 +273,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -407,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -457,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.126.0"
+version = "1.127.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7878050a2321d215eec9db8be09f8db59418b53860ae86cc7042b4094d6cb2bb"
+checksum = "151783f64e0dcddeb4965d08e36c276b4400a46caa88805a2e36d497deaf031a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -492,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.96.0"
+version = "1.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64a6eded248c6b453966e915d32aeddb48ea63ad17932682774eb026fbef5b1"
+checksum = "9aadc669e184501caaa6beafb28c6267fc1baef0810fb58f9b205485ca3f2567"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -516,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.98.0"
+version = "1.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db96d720d3c622fcbe08bae1c4b04a72ce6257d8b0584cb5418da00ae20a344f"
+checksum = "1342a7db8f358d3de0aed2007a0b54e875458e39848d54cc1d46700b2bfcb0a8"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -540,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.100.0"
+version = "1.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fafbdda43b93f57f699c5dfe8328db590b967b8a820a13ccdd6687355dfcc7ca"
+checksum = "ab41ad64e4051ecabeea802d6a17845a91e83287e1dd249e6963ea1ba78c428a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -758,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.6"
+version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b1117b3b2bbe166d11199b540ceed0d0f7676e36e7b962b5a437a9971eac75"
+checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -923,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -965,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -975,9 +975,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -987,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -999,30 +999,30 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "config"
-version = "0.15.19"
+version = "0.15.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30fa8254caad766fc03cb0ccae691e14bf3bd72bfff27f72802ce729551b3d6"
+checksum = "8e68cfe19cd7d23ffde002c24ffa5cda73931913ef394d5eaaa32037dc940c0c"
 dependencies = [
  "async-trait",
  "convert_case 0.6.0",
@@ -1033,8 +1033,8 @@ dependencies = [
  "serde-untagged",
  "serde_core",
  "serde_json",
- "toml",
- "winnow 0.7.15",
+ "toml 1.1.0+spec-1.1.0",
+ "winnow 1.0.0",
  "yaml-rust2",
 ]
 
@@ -1341,9 +1341,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.3.6"
+version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b6c2fc184a6fb6ebcf5f9a5e3bbfa84d8fd268cdfcce4ed508979a6259494d"
+checksum = "f4ae09a41a4b89f94ec1e053623da8340d996bc32c6517d325a9daad9b239358"
 dependencies = [
  "diesel_derives",
  "downcast-rs",
@@ -2459,9 +2459,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -2597,9 +2597,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libgit2-sys"
@@ -2626,9 +2626,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.24"
+version = "1.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839"
+checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
 dependencies = [
  "cc",
  "libc",
@@ -2721,7 +2721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c791ecdf977c99f45f23280405d7723727470f6689a5e6dbf513ac547ae10d"
 dependencies = [
  "serde",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -2763,9 +2763,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -2790,9 +2790,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -2824,9 +2824,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -3519,9 +3519,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
 dependencies = [
  "serde_core",
 ]
@@ -3597,9 +3597,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -3735,9 +3735,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -3919,9 +3919,9 @@ dependencies = [
 
 [[package]]
 name = "tokise"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "decf97738ce15b9e9cc1671ea29b0f6c56538719e1a092d19cc2134bf144e40e"
+checksum = "ba44a1b36f42a95bd21b5e4acc1468547f75a73e7cf619312408d1f74c7fb687"
 dependencies = [
  "futures",
  "gloo",
@@ -3948,6 +3948,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
+dependencies = [
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.1.0+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.0",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3958,6 +3971,15 @@ name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
@@ -3975,11 +3997,11 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
- "winnow 0.7.15",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -4092,9 +4114,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -4146,9 +4168,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"
@@ -4194,9 +4216,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -4551,6 +4573,12 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
 ]
@@ -4785,18 +4813,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2514,6 +2514,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "leap-provision-site"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "gloo-net 0.2.6",
+ "leap-api",
+ "log",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-logger",
+ "web-sys",
+ "yew",
+ "yew-router",
+]
+
+[[package]]
 name = "leap-server"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ members = [
     "leap-site",
     "leap-server",
     "leap-api",
-    "xtask"
+    "leap-provision-site",
+    "xtask",
 ]
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ actix-web-static-files = "4.0"
 anyhow = "1.0"
 async-stream = "0.3.6"
 async-trait = "0.1.89"
-aws-config = "1.8.12"
-aws-sdk-s3 = "1.120.0"
+aws-config = "1.8.15"
+aws-sdk-s3 = "1.127.0"
 built = "0.8.0"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }

--- a/docs/leap_config_template.toml
+++ b/docs/leap_config_template.toml
@@ -16,10 +16,6 @@ initial_backoff = "5 seconds"
 backoff_factor = 1.5
 max_backoff = "2 hours"
 
-[http_config]
-listen_address = "127.0.0.1"
-listen_port = 8080
-
 [s3_config]
 access_key_id = "your-access-key-id"
 secret_access_key = "your-secret-access-key"

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
       {
         imports = [
           ./leap-site
+          ./leap-provision-site
           ./leap-server
           ./leap-linux
         ];

--- a/leap-linux/board/raspberry_pi_4/rootfs_overlay/etc/systemd/system/leap.service
+++ b/leap-linux/board/raspberry_pi_4/rootfs_overlay/etc/systemd/system/leap.service
@@ -3,7 +3,7 @@ Description=main leap service
 Wants=var-lib-leap.mount
 
 [Service]
-ExecStart=/usr/bin/leap-server
+ExecStart=/usr/bin/leap-server --fallback
 Type=exec
 Restart=always
 RestartSec=1

--- a/leap-provision-site/Cargo.toml
+++ b/leap-provision-site/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "leap-provision-site"
+version = "0.1.0"
+edition = "2024"
+description = "Low-bandwidth Educational Access Platform provisioning frontend site"
+license = "MIT OR Apache-2.0"
+authors = ["Javier Alvarez <javier.alvarez@allthingsembedded.net>", "Johannes Frohnhofen <johannes@frohnhofen.com>", "Sivaranjini Chithambaram <sichitha@microsoft.com>"]
+homepage = "https://github.com/t4eq/leap"
+repository = "https://github.com/t4eq/leap"
+
+[dependencies]
+anyhow.workspace = true
+gloo-net.workspace = true
+leap-api.path = "../leap-api"
+log.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+wasm-bindgen-futures.workspace = true
+wasm-bindgen.workspace = true
+wasm-logger.workspace = true
+web-sys.workspace = true
+yew-router.workspace = true
+yew.workspace = true

--- a/leap-provision-site/default.nix
+++ b/leap-provision-site/default.nix
@@ -1,0 +1,46 @@
+{ inputs, ... }:
+{
+  perSystem =
+    { pkgs, ... }:
+    {
+      packages = {
+        # The site is always cross compiled using trunk and wasm. That's why we can build it with the
+        # host toolchain, which already has support for wasm. However, the same is not true for
+        # the target toolchain (aarch64-unknown-linux-musl), so we need to use a nix cross-compilation
+        # strategy there
+        leap-provision-site = pkgs.rustPlatform.buildRustPackage {
+          pname = "leap-provision-site";
+          version = "0.1.0";
+          src = inputs.self;
+
+          cargoLock = {
+            lockFile = ./../Cargo.lock;
+          };
+
+          nativeBuildInputs = with pkgs; [
+            trunk
+            wasm-bindgen-cli_0_2_106
+            dart-sass
+            lld
+          ];
+
+          buildPhase = "
+              runHook preBuild
+              pushd leap-provision-site
+              trunk build --release --offline
+              popd
+              runHook postBuild
+            ";
+
+          installPhase = "
+              runHook preInstall
+              pushd leap-provision-site
+              mkdir -p $out
+              cp -r dist $out/
+              popd
+              runHook postInstall
+            ";
+        };
+      };
+    };
+}

--- a/leap-provision-site/index.html
+++ b/leap-provision-site/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>Low-Bandwidth Educational Access Platform</title>
+  </head>
+  <body></body>
+</html>

--- a/leap-provision-site/src/app.rs
+++ b/leap-provision-site/src/app.rs
@@ -1,0 +1,37 @@
+use yew::prelude::*;
+use yew_router::prelude::*;
+
+#[function_component(StartPage)]
+pub fn start_page() -> Html {
+    html! {
+        <h1>
+            { "Welcome to LEAP" }
+        </h1>
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Routable)]
+pub enum Route {
+    #[at("/")]
+    Start,
+}
+
+fn switch(route: Route) -> Html {
+    match route {
+        Route::Start => {
+            html! {
+                <StartPage>
+                </StartPage>
+            }
+        }
+    }
+}
+
+#[function_component(App)]
+pub fn app() -> Html {
+    html! {
+        <BrowserRouter>
+            <Switch<Route> render={switch} />
+        </BrowserRouter>
+    }
+}

--- a/leap-provision-site/src/lib.rs
+++ b/leap-provision-site/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod app;

--- a/leap-provision-site/src/main.rs
+++ b/leap-provision-site/src/main.rs
@@ -1,0 +1,6 @@
+use leap_provision_site::app::App;
+
+fn main() {
+    wasm_logger::init(wasm_logger::Config::new(log::Level::Debug));
+    yew::Renderer::<App>::new().render();
+}

--- a/leap-server/build.rs
+++ b/leap-server/build.rs
@@ -1,4 +1,19 @@
+use std::path::Path;
+
 use static_files::resource_dir;
+
+fn embed_static_files(src_path: &Path, namespace: &str) -> std::io::Result<()> {
+    println!("cargo::rerun-if-changed={}", src_path.display());
+
+    let mut frontend = resource_dir(src_path);
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let out_dir = Path::new(&out_dir).join(namespace).join("generated.rs");
+    if let Some(parent) = out_dir.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    frontend.with_generated_filename(out_dir);
+    frontend.build()
+}
 
 fn main() -> std::io::Result<()> {
     // Migrations are embedded in the server so that we can initialize a db from scratch
@@ -7,11 +22,17 @@ fn main() -> std::io::Result<()> {
     // Record build-time information
     built::write_built_file()?;
 
-    let frontend_path = std::env::var("LEAP_SERVER_FRONTEND_PATH")
-        .unwrap_or_else(|_| "../leap-site/dist".to_string());
-
     // The LEAP site code is embedded so that we only need to run a single binary
     // without additional dependencies.
-    println!("cargo::rerun-if-changed={frontend_path}");
-    resource_dir(&frontend_path).build()
+    let frontend_path: std::path::PathBuf = std::env::var("LEAP_SERVER_FRONTEND_PATH")
+        .unwrap_or_else(|_| "../leap-site/dist".to_string())
+        .into();
+    embed_static_files(&frontend_path, "site")?;
+
+    let provisioning_path: std::path::PathBuf = std::env::var("LEAP_SERVER_PROVISIONING_PATH")
+        .unwrap_or_else(|_| "../leap-provision-site/dist".to_string())
+        .into();
+    embed_static_files(&provisioning_path, "provisioning")?;
+
+    Ok(())
 }

--- a/leap-server/default.nix
+++ b/leap-server/default.nix
@@ -25,6 +25,7 @@ top@{ inputs, ... }:
             runHook preBuild
             pushd leap-server
             export LEAP_SERVER_FRONTEND_PATH=${config.packages.leap-site}/dist
+            export LEAP_SERVER_PROVISIONING_PATH=${config.packages.leap-provision-site}/dist
             export CARGO_TARGET_DIR=$(pwd)/../target
             export LEAP_SERVER_NIX_GIT_REVISION=${top.config.git-rev}
             cargo build --release --offline -j $NIX_BUILD_CORES --target ${targetPkgs.stdenv.hostPlatform.rust.rustcTarget} --no-default-features

--- a/leap-server/src/api/mod.rs
+++ b/leap-server/src/api/mod.rs
@@ -29,14 +29,13 @@ impl ApiData {
     }
 }
 
-fn register_common_handlers(app: &mut web::ServiceConfig) {
-    app.service(web::scope("api").service(user::get_version));
+fn common_api_handlers() -> actix_web::Scope {
+    web::scope("api").service(user::get_version)
 }
 
 pub fn register_handlers(app: &mut web::ServiceConfig) {
-    register_common_handlers(app);
     app.service(
-        web::scope("api")
+        common_api_handlers()
             .service(user::list_content_metadata)
             .service(user::content_metadata_for_id)
             .service(user::get_content)
@@ -48,6 +47,6 @@ pub fn register_handlers(app: &mut web::ServiceConfig) {
 }
 
 pub fn register_provisioning_handlers(app: &mut web::ServiceConfig) {
-    register_common_handlers(app);
+    app.service(common_api_handlers());
     app.service(web::scope("provision").service(provision::set_network_config));
 }

--- a/leap-server/src/api/mod.rs
+++ b/leap-server/src/api/mod.rs
@@ -5,6 +5,7 @@ use crate::{cfg::LeapConfig, db::Database, downloader::UserCommand};
 use actix_web::web;
 use tokio::sync::mpsc::UnboundedSender;
 
+mod provision;
 mod user;
 
 /// Shared resources used in HTTP handlers
@@ -28,10 +29,14 @@ impl ApiData {
     }
 }
 
+fn register_common_handlers(app: &mut web::ServiceConfig) {
+    app.service(web::scope("api").service(user::get_version));
+}
+
 pub fn register_handlers(app: &mut web::ServiceConfig) {
+    register_common_handlers(app);
     app.service(
         web::scope("api")
-            .service(user::get_version)
             .service(user::list_content_metadata)
             .service(user::content_metadata_for_id)
             .service(user::get_content)
@@ -40,4 +45,9 @@ pub fn register_handlers(app: &mut web::ServiceConfig) {
             .service(user::get_manifest)
             .service(user::log_file),
     );
+}
+
+pub fn register_provisioning_handlers(app: &mut web::ServiceConfig) {
+    register_common_handlers(app);
+    app.service(web::scope("provision").service(provision::set_network_config));
 }

--- a/leap-server/src/api/provision.rs
+++ b/leap-server/src/api/provision.rs
@@ -1,0 +1,12 @@
+use actix_web::{HttpResponse, Responder, post};
+
+#[tracing::instrument(
+    fields(
+        request_id = %uuid::Uuid::new_v4(),
+    )
+)]
+#[post("network_config")]
+async fn set_network_config() -> impl Responder {
+    HttpResponse::Ok()
+}
+

--- a/leap-server/src/api/provision.rs
+++ b/leap-server/src/api/provision.rs
@@ -7,6 +7,5 @@ use actix_web::{HttpResponse, Responder, post};
 )]
 #[post("network_config")]
 async fn set_network_config() -> impl Responder {
-    HttpResponse::Ok()
+    HttpResponse::Ok().await
 }
-

--- a/leap-server/src/cfg.rs
+++ b/leap-server/src/cfg.rs
@@ -5,31 +5,12 @@ use config::Config;
 use http::Uri;
 use secrecy::SecretString;
 
-fn default_listen_addr() -> String {
-    "127.0.0.1".to_string()
-}
-
-fn default_listen_port() -> u16 {
-    8080
-}
-
 fn default_path_style() -> bool {
     false
 }
 
 fn default_aws_region() -> String {
     "us-east-1".to_string()
-}
-
-#[derive(serde::Deserialize, Debug, Clone)]
-pub struct HttpServerConfig {
-    /// Address/interface to listen for TCP connections.
-    #[serde(default = "default_listen_addr")]
-    pub listen_address: String,
-
-    /// Port to listen for TCP connections.
-    #[serde(default = "default_listen_port")]
-    pub listen_port: u16,
 }
 
 #[derive(serde::Deserialize, Debug, Clone)]
@@ -129,9 +110,6 @@ pub struct S3Config {
 pub struct LeapConfig {
     /// Enables debug logging/tracing.
     pub debug: bool,
-
-    /// HTTP Server configuration.
-    pub http_config: HttpServerConfig,
 
     /// Downloader service configuration.
     pub downloader_config: DownloaderConfig,

--- a/leap-server/src/db/mod.rs
+++ b/leap-server/src/db/mod.rs
@@ -33,6 +33,8 @@ pub enum Error {
     MissingVideoInDb(uuid::Uuid),
     #[error("The video being deleted is still present in the manifest: {0}")]
     VideoIsStillInManifest(uuid::Uuid),
+    #[error("Filesystem error: {0}")]
+    IoError(#[from] std::io::Error),
 }
 
 pub type Result<T> = core::result::Result<T, Error>;
@@ -53,8 +55,11 @@ impl Database {
     /// Opens the database using the given configuration. Returns an error if the
     /// database could not be opened. Also loads the manifest file from storage.
     pub async fn open(config: DbConfig) -> Result<Self> {
-        let url = config.db_path();
-        let url = url.to_string_lossy();
+        let db_path = config.db_path();
+        if let Some(dir) = db_path.parent() {
+            tokio::fs::create_dir_all(dir).await?;
+        }
+        let url = db_path.to_string_lossy();
         let manager = Manager::new(url, deadpool_diesel::Runtime::Tokio1);
         let pool: Pool<Manager<_>> = Pool::builder(manager)
             .max_size(config.pool_size)

--- a/leap-server/src/lib.rs
+++ b/leap-server/src/lib.rs
@@ -15,6 +15,19 @@ mod downloader;
 mod manifest;
 mod static_files;
 
+pub async fn run_provisioning(listener: TcpListener) -> anyhow::Result<()> {
+    let server = HttpServer::new(move || {
+        App::new()
+            .wrap(tracing_actix_web::TracingLogger::default())
+            .configure(api::register_provisioning_handlers)
+            .configure(static_files::register_provisioning_files)
+    })
+    .listen(listener)?
+    .run();
+
+    Ok(server.await?)
+}
+
 pub async fn run_app(listener: TcpListener, config: LeapConfig) -> anyhow::Result<()> {
     let database = Arc::new(
         db::Database::open(config.db_config.clone())
@@ -44,7 +57,7 @@ pub async fn run_app(listener: TcpListener, config: LeapConfig) -> anyhow::Resul
             .app_data(api_data.clone())
             .wrap(tracing_actix_web::TracingLogger::default())
             .configure(api::register_handlers)
-            .configure(static_files::register_static_files)
+            .configure(static_files::register_site_files)
     })
     .listen(listener)?
     .run();

--- a/leap-server/src/lib.rs
+++ b/leap-server/src/lib.rs
@@ -1,8 +1,10 @@
 use actix_web::{App, HttpServer, web};
 use anyhow::Context;
 use tokio::sync::mpsc;
+use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-use std::{net::TcpListener, sync::Arc};
+use std::{io::stdout, net::TcpListener, path::Path, sync::Arc};
 
 use crate::cfg::LeapConfig;
 
@@ -14,6 +16,43 @@ mod api;
 mod downloader;
 mod manifest;
 mod static_files;
+
+pub async fn init_logging(logfile: Option<&Path>, debug: bool) {
+    let layered = tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                let level = if debug { "trace" } else { "info" };
+                tracing_subscriber::EnvFilter::new(level)
+            }),
+        )
+        .with(JsonStorageLayer)
+        .with(BunyanFormattingLayer::new("leap-server".into(), stdout));
+
+    if let Some(logfile) = logfile {
+        let logfile = logfile.to_owned();
+        let open_logfile = {
+            move || -> Box<dyn std::io::Write> {
+                Box::new(
+                    std::fs::File::options()
+                        .create(true)
+                        .append(true)
+                        .open(&logfile)
+                        .map_err(|e| format!("Unable to open logfile {logfile:?}: {e}"))
+                        .unwrap(),
+                )
+            }
+        };
+
+        layered
+            .with(BunyanFormattingLayer::new(
+                "leap-server".into(),
+                open_logfile,
+            ))
+            .init();
+    } else {
+        layered.init();
+    }
+}
 
 pub async fn run_provisioning(listener: TcpListener) -> anyhow::Result<()> {
     let server = HttpServer::new(move || {

--- a/leap-server/src/main.rs
+++ b/leap-server/src/main.rs
@@ -8,7 +8,7 @@ struct Args {
     #[arg(short, long)]
     config: Option<PathBuf>,
 
-    /// Fall back to provisioning if the LEAP configuration file could not be open and parsed.
+    /// Fall back to provisioning if the LEAP configuration file could not be opened and parsed.
     #[arg(short = 'f', long = "fallback")]
     provision_fallback: bool,
 

--- a/leap-server/src/main.rs
+++ b/leap-server/src/main.rs
@@ -1,8 +1,6 @@
-use std::{io::stdout, net::TcpListener, path::PathBuf};
+use std::{net::TcpListener, path::PathBuf};
 
 use clap::Parser;
-use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -70,35 +68,7 @@ async fn start_leap_server(args: &Args) -> Result<(), AppError> {
     let config =
         leap_server::cfg::get_config(args.config.as_ref().unwrap_or(&default_config_path()))
             .map_err(AppError::InvalidConfiguration)?;
-
-    let open_logfile = {
-        let logfile = config.db_config.logfile();
-        move || -> Box<dyn std::io::Write> {
-            Box::new(
-                std::fs::File::options()
-                    .create(true)
-                    .append(true)
-                    .open(&logfile)
-                    .map_err(|e| format!("Unable to open logfile {logfile:?}: {e}"))
-                    .unwrap(),
-            )
-        }
-    };
-
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                let level = if config.debug { "trace" } else { "info" };
-                tracing_subscriber::EnvFilter::new(level)
-            }),
-        )
-        .with(JsonStorageLayer)
-        .with(BunyanFormattingLayer::new("leap-server".into(), stdout))
-        .with(BunyanFormattingLayer::new(
-            "leap-server".into(),
-            open_logfile,
-        ))
-        .init();
+    leap_server::init_logging(Some(&config.db_config.logfile()), config.debug).await;
 
     let listener = TcpListener::bind(format!("{}:{}", args.address, args.port))
         .map_err(|e| AppError::RuntimeError(e.into()))?;
@@ -111,11 +81,12 @@ async fn start_leap_server(args: &Args) -> Result<(), AppError> {
     );
     leap_server::run_app(listener, config)
         .await
-        .map_err(|e| AppError::RuntimeError(e.into()))?;
+        .map_err(AppError::RuntimeError)?;
     Ok(())
 }
 
 async fn start_leap_provisioning(args: &Args) -> anyhow::Result<()> {
+    leap_server::init_logging(None, false).await;
     let listener = TcpListener::bind(format!("{}:{}", args.address, args.port))?;
     leap_server::run_provisioning(listener).await?;
     Ok(())
@@ -133,13 +104,16 @@ async fn main() -> anyhow::Result<()> {
         start_leap_provisioning(&args).await?;
     } else {
         match start_leap_server(&args).await {
-            res @ Err(AppError::InvalidConfiguration(_)) => {
+            Err(AppError::InvalidConfiguration(error)) => {
                 if args.provision_fallback {
+                    tracing::error!(
+                        "Failed to start leap with the given configuration file. Falling back to provisioning: {error}"
+                    );
                     start_leap_provisioning(&args).await?;
                 }
-                res
+                Err(AppError::InvalidConfiguration(error))
             }
-            res => res,
+            result => result,
         }?;
     }
 

--- a/leap-server/src/main.rs
+++ b/leap-server/src/main.rs
@@ -10,7 +10,23 @@ struct Args {
     #[arg(short, long)]
     config: Option<PathBuf>,
 
-    /// Displays version information
+    /// Fall back to provisioning if the LEAP configuration file could not be open and parsed.
+    #[arg(short = 'f', long = "fallback")]
+    provision_fallback: bool,
+
+    /// Run provisioning instead of the main application
+    #[arg(short = 'p', long = "provision")]
+    provision: bool,
+
+    /// Address
+    #[arg(long = "address", default_value = "0.0.0.0")]
+    address: String,
+
+    /// Port
+    #[arg(long = "port", default_value = "80")]
+    port: u16,
+
+    /// Displays version information.
     #[arg(short, long)]
     version: bool,
 }
@@ -42,14 +58,18 @@ fn print_version_info() {
     println!("\tFeatures: {}", info.features);
 }
 
-#[actix_web::main]
-async fn main() -> anyhow::Result<()> {
-    let args = Args::parse();
-    if args.version {
-        print_version_info();
-        return Ok(());
-    }
-    let config = leap_server::cfg::get_config(&args.config.unwrap_or_else(default_config_path))?;
+#[derive(thiserror::Error, Debug)]
+enum AppError {
+    #[error("The LEAP configuration could not be loaded: {0}")]
+    InvalidConfiguration(anyhow::Error),
+    #[error("LEAP failed during runtime: {0}")]
+    RuntimeError(anyhow::Error),
+}
+
+async fn start_leap_server(args: &Args) -> Result<(), AppError> {
+    let config =
+        leap_server::cfg::get_config(args.config.as_ref().unwrap_or(&default_config_path()))
+            .map_err(AppError::InvalidConfiguration)?;
 
     let open_logfile = {
         let logfile = config.db_config.logfile();
@@ -80,13 +100,48 @@ async fn main() -> anyhow::Result<()> {
         ))
         .init();
 
-    let listener = TcpListener::bind(format!(
-        "{}:{}",
-        config.http_config.listen_address, config.http_config.listen_port
-    ))?;
+    let listener = TcpListener::bind(format!("{}:{}", args.address, args.port))
+        .map_err(|e| AppError::RuntimeError(e.into()))?;
 
-    println!("Started server at http://{}", listener.local_addr()?);
-    leap_server::run_app(listener, config).await?;
+    println!(
+        "Started server at http://{}",
+        listener
+            .local_addr()
+            .map_err(|e| AppError::RuntimeError(e.into()))?
+    );
+    leap_server::run_app(listener, config)
+        .await
+        .map_err(|e| AppError::RuntimeError(e.into()))?;
+    Ok(())
+}
+
+async fn start_leap_provisioning(args: &Args) -> anyhow::Result<()> {
+    let listener = TcpListener::bind(format!("{}:{}", args.address, args.port))?;
+    leap_server::run_provisioning(listener).await?;
+    Ok(())
+}
+
+#[actix_web::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    if args.version {
+        print_version_info();
+        return Ok(());
+    }
+
+    if args.provision {
+        start_leap_provisioning(&args).await?;
+    } else {
+        match start_leap_server(&args).await {
+            res @ Err(AppError::InvalidConfiguration(_)) => {
+                if args.provision_fallback {
+                    start_leap_provisioning(&args).await?;
+                }
+                res
+            }
+            res => res,
+        }?;
+    }
 
     Ok(())
 }

--- a/leap-server/src/static_files/mod.rs
+++ b/leap-server/src/static_files/mod.rs
@@ -1,6 +1,6 @@
 use actix_web::web;
 
-mod static_files {
+mod site_files {
     #![allow(
         clippy::all,
         clippy::pedantic,
@@ -8,11 +8,29 @@ mod static_files {
         unused_imports,
         unused_variables
     )]
-    include!(concat!(env!("OUT_DIR"), "/generated.rs"));
+    include!(concat!(env!("OUT_DIR"), "/site/generated.rs"));
 }
 
-pub fn register_static_files(app: &mut web::ServiceConfig) {
-    let generated = static_files::generate();
+mod provisioning_files {
+    #![allow(
+        clippy::all,
+        clippy::pedantic,
+        clippy::nursery,
+        unused_imports,
+        unused_variables
+    )]
+    include!(concat!(env!("OUT_DIR"), "/provisioning/generated.rs"));
+}
+
+pub fn register_provisioning_files(app: &mut web::ServiceConfig) {
+    let generated = provisioning_files::generate();
+    app.service(
+        actix_web_static_files::ResourceFiles::new("/", generated).resolve_not_found_to_root(),
+    );
+}
+
+pub fn register_site_files(app: &mut web::ServiceConfig) {
+    let generated = site_files::generate();
     app.service(
         actix_web_static_files::ResourceFiles::new("/", generated).resolve_not_found_to_root(),
     );

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -20,6 +20,15 @@ struct BuildArgs {
 struct RunArgs {
     #[command(flatten)]
     build_args: BuildArgs,
+
+    #[arg(short, long, default_value = "127.0.0.1")]
+    address: String,
+
+    #[arg(short, long, default_value = "8080")]
+    port: u16,
+
+    #[arg(long)]
+    provision: bool,
 }
 
 #[derive(Debug, clap::Subcommand)]
@@ -50,6 +59,11 @@ fn build(args: &BuildArgs) -> anyhow::Result<()> {
         cmd!(shell, "trunk build {offline...} {release...}").run()?;
     }
 
+    {
+        let _dir = shell.push_dir("leap-provision-site");
+        cmd!(shell, "trunk build {offline...} {release...}").run()?;
+    }
+
     // Now build the backend
     cmd!(
         shell,
@@ -63,11 +77,15 @@ fn build(args: &BuildArgs) -> anyhow::Result<()> {
 fn run(args: &RunArgs) -> anyhow::Result<()> {
     build(&args.build_args)?;
 
+    let address = &args.address;
+    let port = format!("{}", args.port);
+
     let release = args.build_args.release.then_some("--release");
+    let provision = args.provision.then_some("--provision");
     let shell = xshell::Shell::new()?;
     cmd!(
         shell,
-        "cargo run {release...} --bin leap-server -- --config ./docs/leap_config_template.toml"
+        "cargo run {release...} --bin leap-server -- --config ./docs/leap_config_template.toml --address {address} --port {port} {provision...}"
     )
     .run()?;
 


### PR DESCRIPTION
- Creates a `leap-provision-site` crate to host the frontend of the provisioning functionality for LEAP.
- Hooks this site to the `leap-server`.
- By default, `leap-server` attempts to start itself using the given configuration path or using the default path. If the configuration is not present or is invalid, and `--fallback` is given, it falls back to a provisioning mode, in which it serves the provisioning frontend and uses a different set of HTTP handlers for the API.
- Additionally, it is possible to ask the `leap-server` directly to start in provisioning mode by passing the `--provision` flag.
- `xtask` replicates the `--provision` flag and passes it to the leap-server binary when given to `cargo rr`.
- The HTTP configuration is moved from the configuration file to cli arguments. This helps to share these settings between the 2 modes.
- Updates the aws crates to patch https://github.com/T4EQ/leap/security/dependabot/1 and https://github.com/T4EQ/leap/security/dependabot/2

Closes #58 