### PR TITLE
Configure cargo-deny to not fail a PR on new advisories

### DIFF
--- a/.github/workflows/cargo-deny.yaml
+++ b/.github/workflows/cargo-deny.yaml
@@ -1,0 +1,20 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+
+    # Prevent sudden announcement of a new advisory from failing ci
+    # We use dependabot to raise advisories as well, so this is an additional check.
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: EmbarkStudios/cargo-deny-action@v2
+      with:
+        command: check ${{ matrix.checks }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -81,9 +81,3 @@ jobs:
     - name: 'Install rust-toolchain.toml'
       run: rustup toolchain install
     - run: cargo doc
-
-  cargo-deny:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: EmbarkStudios/cargo-deny-action@v2


### PR DESCRIPTION
While it should definitely warn us, let's allow merging PRs that are anyway unrelated to the advisories that triggered. Github dependabot also raises advisories via a separate mechanism, so we should detect them.

I'm also going to configure the renovate bot to automate dependency updates to the extent that it is possible.