### PR TITLE
Fix initial manifest fetch

### DIFF
--- a/leap-server/src/downloader.rs
+++ b/leap-server/src/downloader.rs
@@ -3,6 +3,7 @@ pub mod s3backend;
 mod tasks;
 
 use std::{path::PathBuf, sync::Arc};
+use tokio::time::Duration;
 
 use crate::{
     cfg::{DownloaderConfig, S3Config},
@@ -137,6 +138,15 @@ pub async fn run_downloader(
         backend,
         db,
     };
+
+    // Wait for time sync before starting anything
+    tracing::info!("Waiting for time sync before starting downloader");
+    let _ = crate::utils::wait_timesync(Duration::from_secs(30))
+        .await
+        .inspect(|_| tracing::info!("Time synchronized before downloader startup"))
+        .inspect_err(|e| {
+            tracing::error!("Time synchronization failed before downloader startup: {e:?}")
+        });
 
     // We keep track of the last pending task so that we can cancel it if we discovered an
     // even-newer manifest

--- a/leap-server/src/downloader/tasks.rs
+++ b/leap-server/src/downloader/tasks.rs
@@ -208,7 +208,7 @@ pub async fn download_manifest_task(
                         tracing::error!("Video {} failed. Backing off for {:?}", job.video.id, job.backoff_time);
                         let wakeup_time = tokio::time::Instant::now() + job.backoff_time;
                         job.backoff_time = job.backoff_time .mul_f64( ctx.config.retry_params.backoff_factor);
-                        backoff_list.push_back((wakeup_time, job));
+                        backoff_list.push_back((wakeup_time, *job));
                     }
                     Err(DownloadJobError::Unrecoverable(job)) => {
                         let msg = format!("Unrecoverable download error for video: {}", job.video.id);
@@ -225,8 +225,18 @@ pub async fn download_manifest_task(
 
 #[derive(Debug)]
 enum DownloadJobError {
-    ShouldRetry(Job),
-    Unrecoverable(Job),
+    ShouldRetry(Box<Job>),
+    Unrecoverable(Box<Job>),
+}
+
+impl DownloadJobError {
+    #[cfg(test)]
+    fn to_job(&self) -> Job {
+        match self {
+            DownloadJobError::ShouldRetry(job) => (**job).clone(),
+            DownloadJobError::Unrecoverable(job) => (**job).clone(),
+        }
+    }
 }
 
 /// download job task
@@ -245,14 +255,14 @@ async fn download_job_task(ctx: DownloadContext, job: Job) -> Result<(), Downloa
     if let Some(dir) = target_filepath.parent() {
         tokio::fs::create_dir_all(dir).await.map_err(|e| {
             tracing::error!("Error creating directory: {dir:?}. Error: {e}");
-            DownloadJobError::ShouldRetry(job.clone())
+            DownloadJobError::ShouldRetry(Box::new(job.clone()))
         })?;
     }
     let mut target_file = tokio::fs::File::create(&target_filepath)
         .await
         .map_err(|e| {
             tracing::error!("Error creating file: {target_filepath:?}. Error: {e}");
-            DownloadJobError::ShouldRetry(job.clone())
+            DownloadJobError::ShouldRetry(Box::new(job.clone()))
         })?;
 
     let translate_error = |e: crate::db::Result<()>| {
@@ -260,7 +270,7 @@ async fn download_job_task(ctx: DownloadContext, job: Job) -> Result<(), Downloa
             tracing::error!(
                 "Error setting download status for file: {target_filepath:?}. Error: {e}",
             );
-            DownloadJobError::Unrecoverable(job.clone())
+            DownloadJobError::Unrecoverable(Box::new(job.clone()))
         })
     };
 
@@ -279,14 +289,14 @@ async fn download_job_task(ctx: DownloadContext, job: Job) -> Result<(), Downloa
 
                 translate_error(ctx.db.set_download_failed(video.id, &error_msg).await)?;
 
-                return Err(DownloadJobError::ShouldRetry(job.clone()));
+                return Err(DownloadJobError::ShouldRetry(Box::new(job.clone())));
             }
         };
 
         hasher.update(&chunk[..]);
         target_file.write_all(&chunk[..]).await.map_err(|e| {
             tracing::error!("Error writing file: {target_filepath:?}. Error: {e}");
-            DownloadJobError::ShouldRetry(job.clone())
+            DownloadJobError::ShouldRetry(Box::new(job.clone()))
         })?;
         total_size += chunk.len();
 
@@ -311,7 +321,7 @@ async fn download_job_task(ctx: DownloadContext, job: Job) -> Result<(), Downloa
         let err_msg = &format!("Got hash: {hash}. Expected: {}", video.sha256);
         translate_error(ctx.db.set_download_failed(video.id, err_msg).await)?;
         tracing::error!("{}", err_msg);
-        return Err(DownloadJobError::ShouldRetry(job.clone()));
+        return Err(DownloadJobError::ShouldRetry(Box::new(job.clone())));
     }
 
     translate_error(ctx.db.set_downloaded(video.id, &target_filepath).await)?;
@@ -661,13 +671,17 @@ pub mod test {
         .await;
 
         assert_that!(
-            result,
-            err(matches_pattern!(DownloadJobError::ShouldRetry(
-                matches_pattern!(Job {
-                    video: matches_pattern!(Video { id: &id, .. }),
-                    backoff_time: &ctx.download_ctx.config.retry_params.initial_backoff,
-                })
-            )))
+            &result,
+            err(all!(
+                matches_pattern!(DownloadJobError::ShouldRetry(_)),
+                property!(
+                    DownloadJobError.to_job(),
+                    matches_pattern!(Job {
+                        video: matches_pattern!(Video { id: &id, .. }),
+                        backoff_time: &ctx.download_ctx.config.retry_params.initial_backoff,
+                    })
+                )
+            ))
         );
 
         // Check that file is available in the database
@@ -784,13 +798,17 @@ pub mod test {
         .await;
 
         assert_that!(
-            result,
-            err(matches_pattern!(DownloadJobError::ShouldRetry(
-                matches_pattern!(Job {
-                    video: matches_pattern!(Video { id: &id, .. }),
-                    backoff_time: &ctx.download_ctx.config.retry_params.initial_backoff,
-                })
-            )))
+            &result,
+            err(all!(
+                matches_pattern!(DownloadJobError::ShouldRetry(_)),
+                property!(
+                    DownloadJobError.to_job(),
+                    matches_pattern!(Job {
+                        video: matches_pattern!(Video { id: &id, .. }),
+                        backoff_time: &ctx.download_ctx.config.retry_params.initial_backoff,
+                    })
+                )
+            ))
         );
 
         // Check that file is available in the database

--- a/leap-server/src/lib.rs
+++ b/leap-server/src/lib.rs
@@ -11,6 +11,7 @@ use crate::{api::ProvisionApiData, cfg::LeapConfig};
 pub mod build_info;
 pub mod cfg;
 pub mod db;
+pub mod utils;
 
 mod api;
 mod downloader;

--- a/leap-server/src/provision/cfg.rs
+++ b/leap-server/src/provision/cfg.rs
@@ -4,8 +4,9 @@
 use std::time::Duration;
 
 use super::{CONTENT_PATH, MOUNT_PATH, RUNTIME_PATH};
-use crate::cfg::{
-    DEFAULT_CONFIG_PATH, DbConfig, DownloaderConfig, LeapConfig, RetryParams, S3Config,
+use crate::{
+    cfg::{DEFAULT_CONFIG_PATH, DbConfig, DownloaderConfig, LeapConfig, RetryParams, S3Config},
+    utils,
 };
 
 impl From<&leap_api::provision::config::post::LeapConfig> for LeapConfig {
@@ -49,33 +50,6 @@ impl From<&leap_api::provision::config::post::LeapConfig> for LeapConfig {
     }
 }
 
-async fn check_timesync() -> anyhow::Result<bool> {
-    let output = tokio::process::Command::new("timedatectl")
-        .arg("show")
-        .arg("-P")
-        .arg("NTPSynchronized")
-        .output()
-        .await?;
-    if !output.status.success() {
-        tracing::error!("Failure checking time synchronization {output:?}");
-        anyhow::bail!("Failure checking time synchronization {output:?}");
-    }
-
-    Ok(output.stdout == b"yes\n")
-}
-
-async fn wait_timesync(timeout: std::time::Duration) -> anyhow::Result<()> {
-    let start = std::time::Instant::now();
-    while std::time::Instant::now() - start < timeout {
-        if check_timesync().await? {
-            return Ok(());
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
-
-    anyhow::bail!("Timeout while waiting for time synchronization");
-}
-
 /// Saves LEAP configuration to disk. Ensures that the S3 credentials are valid by enabling
 /// temporarily the network connection, then waiting for time sync (NTP) to ensure HTTPs will work,
 /// and finally by checking connectivity to S3. The provision network configuration is restored
@@ -107,7 +81,7 @@ pub async fn provision_configuration(
             const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
             // This is a best-effort synchronization. It might be that date was previously
             // synchronized, so we try to connect to S3 either way.
-            let _ = wait_timesync(TIMEOUT)
+            let _ = utils::wait_timesync(TIMEOUT)
                 .await
                 .inspect(|_| tracing::info!("Time synchronized"))
                 .inspect_err(|e| tracing::error!("Time synchronization failed: {e:?}"));

--- a/leap-server/src/utils.rs
+++ b/leap-server/src/utils.rs
@@ -1,0 +1,28 @@
+use std::time::Duration;
+
+pub async fn check_timesync() -> anyhow::Result<bool> {
+    let output = tokio::process::Command::new("timedatectl")
+        .arg("show")
+        .arg("-P")
+        .arg("NTPSynchronized")
+        .output()
+        .await?;
+    if !output.status.success() {
+        tracing::error!("Failure checking time synchronization {output:?}");
+        anyhow::bail!("Failure checking time synchronization {output:?}");
+    }
+
+    Ok(output.stdout == b"yes\n")
+}
+
+pub async fn wait_timesync(timeout: Duration) -> anyhow::Result<()> {
+    let start = std::time::Instant::now();
+    while std::time::Instant::now() - start < timeout {
+        if check_timesync().await? {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    anyhow::bail!("Timeout while waiting for time synchronization");
+}


### PR DESCRIPTION
Fixes #63 by waiting for timesync during boot before fetching the manifest.

Also fixes a [result_large_err clippy lint](https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err) by boxing the error data to ensure it does not pessimize the stack frame size and instead allocates it on the heap.