### PR TITLE
Make the application buildable on macOS again

### DIFF
--- a/leap-provision-site/default.nix
+++ b/leap-provision-site/default.nix
@@ -32,6 +32,10 @@
               runHook postBuild
             ";
 
+          checkPhase = "
+              # No tests for this package
+            ";
+
           installPhase = "
               runHook preInstall
               pushd leap-provision-site

--- a/leap-server/Cargo.toml
+++ b/leap-server/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/t4eq/leap"
 [features]
 default = ["git2"]
 git2 = ["built/git2"]
+provision = ["dbus"]
 
 [dependencies]
 actix-web-static-files.workspace = true
@@ -23,7 +24,7 @@ aws-sdk-s3.workspace = true
 chrono.workspace = true
 clap.workspace = true
 config.workspace = true
-dbus.workspace = true
+dbus = { workspace = true, optional = true }
 deadpool-diesel.workspace = true
 diesel.workspace = true
 diesel_migrations.workspace = true

--- a/leap-server/default.nix
+++ b/leap-server/default.nix
@@ -31,7 +31,7 @@ top@{ inputs, ... }:
             # GCC compiles by default with -moutline-atomics, but this is not supported by the musl
             # variant of the build, as it would require linking to libgcc. This is needed by libdbus.
             export CFLAGS="$CFLAGS ${opts.extra-cflags or ""}"
-            cargo build --release --offline -j $NIX_BUILD_CORES --target ${targetPkgs.stdenv.hostPlatform.rust.rustcTarget} --no-default-features
+            cargo build --release --offline -j $NIX_BUILD_CORES --target ${targetPkgs.stdenv.hostPlatform.rust.rustcTarget} --no-default-features --features provision
             popd
             runHook postBuild
           '';

--- a/leap-server/src/api.rs
+++ b/leap-server/src/api.rs
@@ -6,12 +6,12 @@
 
 use std::sync::Arc;
 
-use crate::provision::DynProvision;
 use crate::{cfg::LeapConfig, db::Database, downloader::UserCommand};
 
 use actix_web::web;
 use tokio::sync::mpsc::UnboundedSender;
 
+#[cfg(feature = "provision")]
 mod provision;
 mod user;
 
@@ -39,17 +39,19 @@ impl ApiData {
     }
 }
 
+#[cfg(feature = "provision")]
 /// Shared resources used in provisioning HTTP handlers.
 #[derive(Debug)]
 pub struct ProvisionApiData {
     /// The provisioning engine.
-    provision: DynProvision,
+    provision: crate::provision::DynProvision,
 }
 
+#[cfg(feature = "provision")]
 impl ProvisionApiData {
     pub async fn new() -> anyhow::Result<Self> {
         Ok(Self {
-            provision: DynProvision::new().await?,
+            provision: crate::provision::DynProvision::new().await?,
         })
     }
 }
@@ -72,6 +74,7 @@ pub fn register_handlers(app: &mut web::ServiceConfig) {
     );
 }
 
+#[cfg(feature = "provision")]
 /// Registers the provisioning API handlers.
 pub fn register_provisioning_handlers(app: &mut web::ServiceConfig) {
     app.service(common_api_handlers());

--- a/leap-server/src/lib.rs
+++ b/leap-server/src/lib.rs
@@ -34,12 +34,14 @@
 //! To start the provisioning server, use [`run_provisioning`]:
 //!
 //! ```rust,no_run
+//! #[cfg(feature = "provision")]
 //! use leap_server::run_provisioning;
 //! use std::net::TcpListener;
 //!
 //! #[tokio::main]
 //! async fn main() -> anyhow::Result<()> {
 //!     let listener = TcpListener::bind("127.0.0.1:9000")?;
+//!     #[cfg(feature = "provision")]
 //!     run_provisioning(listener).await?;
 //!     Ok(())
 //! }
@@ -47,19 +49,20 @@
 //!
 use actix_web::{App, HttpServer, web};
 use anyhow::Context;
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::mpsc;
 use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use std::{io::stdout, net::TcpListener, path::Path, sync::Arc};
 
-use crate::{api::ProvisionApiData, cfg::LeapConfig};
+use cfg::LeapConfig;
 
 pub mod build_info;
 pub mod cfg;
 pub mod db;
 pub mod downloader;
 pub mod manifest;
+#[cfg(feature = "provision")]
 pub mod provision;
 pub mod utils;
 
@@ -103,8 +106,9 @@ pub async fn init_logging(logfile: Option<&Path>, debug: bool) {
     }
 }
 
+#[cfg(feature = "provision")]
 pub async fn run_provisioning(listener: TcpListener) -> anyhow::Result<()> {
-    let app_data = web::Data::new(Mutex::new(ProvisionApiData::new().await?));
+    let app_data = web::Data::new(tokio::sync::Mutex::new(api::ProvisionApiData::new().await?));
     let server = HttpServer::new(move || {
         App::new()
             .app_data(app_data.clone())

--- a/leap-server/src/main.rs
+++ b/leap-server/src/main.rs
@@ -85,6 +85,7 @@ async fn start_leap_server(args: &Args) -> Result<(), AppError> {
     Ok(())
 }
 
+#[cfg(feature = "provision")]
 async fn start_leap_provisioning(args: &Args) -> anyhow::Result<()> {
     leap_server::init_logging(None, false).await;
     let listener = TcpListener::bind(format!("{}:{}", args.address, args.port))?;
@@ -100,21 +101,28 @@ async fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    if args.provision {
-        start_leap_provisioning(&args).await?;
-    } else {
-        match start_leap_server(&args).await {
-            Err(AppError::InvalidConfiguration(error)) => {
-                if args.provision_fallback {
-                    tracing::error!(
-                        "Failed to start leap with the given configuration file. Falling back to provisioning: {error}"
-                    );
-                    start_leap_provisioning(&args).await?;
-                }
-                Err(AppError::InvalidConfiguration(error))
+    std::cfg_select! {
+        feature = "provision" => {
+            if args.provision {
+                start_leap_provisioning(&args).await?;
+            } else {
+                match start_leap_server(&args).await {
+                    Err(AppError::InvalidConfiguration(error)) => {
+                        if args.provision_fallback {
+                            tracing::error!(
+                                "Failed to start leap with the given configuration file. Falling back to provisioning: {error}"
+                            );
+                            start_leap_provisioning(&args).await?;
+                        }
+                        Err(AppError::InvalidConfiguration(error))
+                    }
+                    result => result,
+                }?;
             }
-            result => result,
-        }?;
+        }
+        _ => {
+            start_leap_server(&args).await?;
+        }
     }
 
     Ok(())

--- a/leap-server/src/static_files.rs
+++ b/leap-server/src/static_files.rs
@@ -17,11 +17,13 @@ mod provisioning_files {
         clippy::pedantic,
         clippy::nursery,
         unused_imports,
-        unused_variables
+        unused_variables,
+        dead_code
     )]
     include!(concat!(env!("OUT_DIR"), "/provisioning/generated.rs"));
 }
 
+#[cfg(feature = "provision")]
 pub fn register_provisioning_files(app: &mut web::ServiceConfig) {
     let generated = provisioning_files::generate();
     app.service(

--- a/leap-server/src/utils.rs
+++ b/leap-server/src/utils.rs
@@ -12,18 +12,26 @@ use std::time::Duration;
 /// Returns `Ok(true)` if synchronized, `Ok(false)` if not, or an error if `timedatectl` does not
 /// exit with a zero status code.
 pub async fn check_timesync() -> anyhow::Result<bool> {
-    let output = tokio::process::Command::new("timedatectl")
-        .arg("show")
-        .arg("-P")
-        .arg("NTPSynchronized")
-        .output()
-        .await?;
-    if !output.status.success() {
-        tracing::error!("Failure checking time synchronization {output:?}");
-        anyhow::bail!("Failure checking time synchronization {output:?}");
-    }
+    std::cfg_select! {
+        target_os = "linux" => {
+            let output = tokio::process::Command::new("timedatectl")
+                .arg("show")
+                .arg("-P")
+                .arg("NTPSynchronized")
+                .output()
+                .await?;
+            if !output.status.success() {
+                tracing::error!("Failure checking time synchronization {output:?}");
+                anyhow::bail!("Failure checking time synchronization {output:?}");
+            }
 
-    Ok(output.stdout == b"yes\n")
+            Ok(output.stdout == b"yes\n")
+        }
+        _ => {
+            // We don't support time sync in other operating systems
+            Ok(false)
+        }
+    }
 }
 
 /// Waits for the system time to be synchronized with NTP.
@@ -34,13 +42,21 @@ pub async fn check_timesync() -> anyhow::Result<bool> {
 ///
 /// Returns an error if the timeout is reached before synchronization is confirmed.
 pub async fn wait_timesync(timeout: Duration) -> anyhow::Result<()> {
-    let start = std::time::Instant::now();
-    while std::time::Instant::now() - start < timeout {
-        if check_timesync().await? {
-            return Ok(());
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
+    std::cfg_select! {
+        target_os = "linux" => {
+            let start = std::time::Instant::now();
+            while std::time::Instant::now() - start < timeout {
+                if check_timesync().await? {
+                    return Ok(());
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
 
-    anyhow::bail!("Timeout while waiting for time synchronization");
+            anyhow::bail!("Timeout while waiting for time synchronization");
+        }
+        _ => {
+            let _ = timeout;
+            anyhow::bail!("Time sync is not supported in this operating system");
+        }
+    }
 }

--- a/leap-site/default.nix
+++ b/leap-site/default.nix
@@ -32,6 +32,10 @@
               runHook postBuild
             ";
 
+          checkPhase = "
+              # No tests for this package
+            ";
+
           installPhase = "
               runHook preInstall
               pushd leap-site


### PR DESCRIPTION
With the addition of the provisioning APIs, we lost the ability to just run the server on other operating systems like macOS since we require specific linux tools like dbus. 

Provisioning is now disabled in local builds but enabled in nix builds, so the buildroot image still includes provisioning. One can also enable it manually using the `provision` feature.