### PR TITLE
Forward state updates to the client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2535,6 +2535,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 name = "leap-api"
 version = "0.2.0"
 dependencies = [
+ "chrono",
  "http 1.5.0",
  "humantime-serde",
  "secrecy",

--- a/leap-api/Cargo.toml
+++ b/leap-api/Cargo.toml
@@ -9,7 +9,8 @@ homepage = "https://github.com/t4eq/leap"
 repository = "https://github.com/t4eq/leap"
 
 [dependencies]
-serde.workspace = true
+chrono.workspace = true
 http.workspace = true
-secrecy.workspace = true
 humantime-serde.workspace = true
+secrecy.workspace = true
+serde.workspace = true

--- a/leap-api/src/lib.rs
+++ b/leap-api/src/lib.rs
@@ -34,12 +34,14 @@ pub mod api {
     pub mod content {
         pub mod meta {
             pub mod get {
-                pub use crate::types::{GroupedSection, LocalVideoMeta, Progress, VideoStatus};
+                pub use crate::types::{
+                    GroupedSection, LocalVideoMeta, ManifestMeta, Progress, VideoStatus,
+                };
 
                 /// The response to the `GET` `api/content/meta` request
                 #[derive(Debug, serde::Deserialize, serde::Serialize, PartialEq)]
                 pub struct Response {
-                    pub videos: Vec<GroupedSection>,
+                    pub meta: Option<ManifestMeta>,
                 }
             }
 

--- a/leap-api/src/types.rs
+++ b/leap-api/src/types.rs
@@ -92,6 +92,19 @@ pub struct GroupedSection {
     pub content: Vec<LocalVideoMeta>,
 }
 
+/// Metadata for the manifest file
+#[derive(Debug, serde::Deserialize, serde::Serialize, PartialEq, Clone)]
+pub struct ManifestMeta {
+    /// Name of the manifest.
+    pub name: String,
+
+    /// Date of the manifest.
+    pub date: chrono::NaiveDate,
+
+    /// Sections ordered as displayed.
+    pub content: Vec<GroupedSection>,
+}
+
 #[derive(Debug, serde::Deserialize, serde::Serialize, PartialEq, Clone)]
 pub struct BuildInfo {
     pub name: String,

--- a/leap-server/src/api.rs
+++ b/leap-server/src/api.rs
@@ -4,57 +4,16 @@
 //! shared across HTTP handlers, and provides functions to register handlers for
 //! both the main API and the provisioning API.
 
-use std::sync::Arc;
-
-use crate::{cfg::LeapConfig, db::Database, downloader::UserCommand};
-
 use actix_web::web;
-use tokio::sync::mpsc::UnboundedSender;
 
 #[cfg(feature = "provision")]
 mod provision;
 mod user;
 
-/// Shared resources used in HTTP handlers.
-pub struct ApiData {
-    /// The LEAP configuration.
-    config: LeapConfig,
-    /// A handle to the database.
-    db: Arc<Database>,
-    /// A channel to send commands to the downloader service.
-    cmd_sender: UnboundedSender<UserCommand>,
-}
-
-impl ApiData {
-    pub fn new(
-        config: LeapConfig,
-        db: Arc<Database>,
-        cmd_sender: UnboundedSender<UserCommand>,
-    ) -> Self {
-        Self {
-            config,
-            db,
-            cmd_sender,
-        }
-    }
-}
+pub use user::ApiData;
 
 #[cfg(feature = "provision")]
-/// Shared resources used in provisioning HTTP handlers.
-#[derive(Debug)]
-pub struct ProvisionApiData {
-    /// The provisioning engine.
-    provision: crate::provision::DynProvision,
-}
-
-#[cfg(feature = "provision")]
-impl ProvisionApiData {
-    pub async fn new() -> anyhow::Result<Self> {
-        Ok(Self {
-            provision: crate::provision::DynProvision::new().await?,
-        })
-    }
-}
+pub use provision::ProvisionApiData;
 
 fn common_api_handlers() -> actix_web::Scope {
     web::scope("api").service(user::get_version)
@@ -64,6 +23,7 @@ fn common_api_handlers() -> actix_web::Scope {
 pub fn register_handlers(app: &mut web::ServiceConfig) {
     app.service(
         common_api_handlers()
+            .service(user::events)
             .service(user::list_content_metadata)
             .service(user::content_metadata_for_id)
             .service(user::get_content)

--- a/leap-server/src/api/provision.rs
+++ b/leap-server/src/api/provision.rs
@@ -18,7 +18,20 @@ use leap_api::types::DeviceType;
 use serde::Deserialize;
 use tokio::sync::Mutex;
 
-use crate::api::ProvisionApiData;
+/// Shared resources used in provisioning HTTP handlers.
+#[derive(Debug)]
+pub struct ProvisionApiData {
+    /// The provisioning engine.
+    provision: crate::provision::DynProvision,
+}
+
+impl ProvisionApiData {
+    pub async fn new() -> anyhow::Result<Self> {
+        Ok(Self {
+            provision: crate::provision::DynProvision::new().await?,
+        })
+    }
+}
 
 impl From<crate::provision::BlockDeviceType> for DeviceType {
     fn from(value: crate::provision::BlockDeviceType) -> Self {

--- a/leap-server/src/api/user.rs
+++ b/leap-server/src/api/user.rs
@@ -10,6 +10,7 @@
 //! - Fetching the system log file.
 
 mod event_handler;
+mod utils;
 
 use std::sync::Arc;
 use std::{convert::Infallible, str::FromStr};
@@ -22,7 +23,7 @@ use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::instrument::Instrument;
 
-use leap_api::api::content::meta::get::{GroupedSection, LocalVideoMeta, Progress, VideoStatus};
+use leap_api::api::content::meta::get::{LocalVideoMeta, Progress, VideoStatus};
 
 use crate::{cfg::LeapConfig, db::Database, downloader::UserCommand};
 
@@ -127,7 +128,7 @@ async fn events(api_data: web::Data<ApiData>) -> impl Responder {
         let mut keep_alive = tokio::time::interval(CONTENT_EVENT_KEEP_ALIVE_INTERVAL);
         keep_alive.tick().await;
         {
-            let content = content_changes.borrow_and_update();
+            let content = Arc::clone(&*content_changes.borrow_and_update());
             match serialize_content_event(&content) {
                 Ok(event) => yield Result::<Bytes, Infallible>::Ok(event),
                 Err(e) => {
@@ -148,7 +149,7 @@ async fn events(api_data: web::Data<ApiData>) -> impl Responder {
                     // Progress is persisted for every downloaded chunk. Wait briefly and mark the
                     // newest revision as seen so a burst produces at most one snapshot per interval.
                     tokio::time::sleep(CONTENT_EVENT_INTERVAL).await;
-                    let content = content_changes.borrow_and_update();
+                    let content = Arc::clone(&*content_changes.borrow_and_update());
 
                     match serialize_content_event(&content) {
                         Ok(event) => yield Result::<Bytes, Infallible>::Ok(event),
@@ -197,35 +198,11 @@ async fn get_version() -> impl Responder {
 /// This endpoint returns a list of sections, each containing a list of video metadata.
 #[get("/content/meta")]
 async fn list_content_metadata(api_data: web::Data<ApiData>) -> impl Responder {
-    use leap_api::api::content::meta::get::Response;
-
-    let sections = match api_data
-        .db
-        .current_manifest_sections()
-        .instrument(tracing::info_span!(
-            "Querying manifest information from database"
-        ))
-        .await
-    {
-        Ok(sections) => sections,
-        Err(e) => {
-            return HttpResponse::InternalServerError()
-                .body(format!("Unexpected error querying content list: {e:?}"));
-        }
-    };
-
-    let _span =
-        tracing::info_span!("Collecting manifest information as /content/meta response").entered();
-
-    let videos = sections
-        .into_iter()
-        .map(|(name, content)| {
-            let content = content.into_iter().map(|v| v.into()).collect();
-            GroupedSection { name, content }
-        })
-        .collect();
-
-    HttpResponse::Ok().json(Response { videos })
+    match utils::content_metadata(&api_data.db).await {
+        Ok(content) => HttpResponse::Ok().json(content),
+        Err(e) => HttpResponse::InternalServerError()
+            .body(format!("Unexpected error querying content metadata: {e:?}")),
+    }
 }
 
 #[tracing::instrument(

--- a/leap-server/src/api/user.rs
+++ b/leap-server/src/api/user.rs
@@ -9,18 +9,54 @@
 //! - Fetching the latest manifest.
 //! - Fetching the system log file.
 
-use std::str::FromStr;
+mod event_handler;
+
+use std::sync::Arc;
+use std::{convert::Infallible, str::FromStr};
 
 use actix_web::{
     HttpRequest, HttpResponse, Responder, get, post,
     web::{self, Bytes, BytesMut},
 };
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
+use tokio::sync::mpsc::UnboundedSender;
 use tracing::instrument::Instrument;
 
 use leap_api::api::content::meta::get::{GroupedSection, LocalVideoMeta, Progress, VideoStatus};
 
-use crate::{api::ApiData, downloader::UserCommand};
+use crate::{cfg::LeapConfig, db::Database, downloader::UserCommand};
+
+/// Shared resources used in HTTP handlers.
+pub struct ApiData {
+    /// The LEAP configuration.
+    config: LeapConfig,
+    /// A handle to the database.
+    db: Arc<Database>,
+    /// A channel to send commands to the downloader service.
+    cmd_sender: UnboundedSender<UserCommand>,
+    /// DB State event handler. Receives db update events and emits content metadata responses
+    /// to be forwarded to any HTTP subscribers.
+    event_handler: event_handler::StateEventHandler,
+}
+
+impl ApiData {
+    pub async fn new(
+        config: LeapConfig,
+        db: Arc<Database>,
+        cmd_sender: UnboundedSender<UserCommand>,
+    ) -> Self {
+        let notifier = db.notifier();
+        let event_handler = event_handler::StateEventHandler::start(notifier, Arc::clone(&db))
+            .await
+            .expect("Unable to construct event handler notifier");
+        Self {
+            config,
+            db,
+            cmd_sender,
+            event_handler,
+        }
+    }
+}
 
 impl From<crate::db::DownloadStatus> for VideoStatus {
     fn from(value: crate::db::DownloadStatus) -> Self {
@@ -62,6 +98,67 @@ impl From<crate::build_info::BuildInfo> for leap_api::api::version::get::BuildIn
             features: value.features.to_string(),
         }
     }
+}
+
+fn serialize_content_event(
+    content: &leap_api::api::content::meta::get::Response,
+) -> serde_json::Result<Bytes> {
+    serde_json::to_string(content).map(|content| Bytes::from(format!("data: {content}\n\n")))
+}
+
+#[tracing::instrument(
+    skip(api_data)
+    fields(
+        request_id = %uuid::Uuid::new_v4(),
+    )
+)]
+/// Streams complete content metadata snapshots whenever the content changes.
+#[get("/content/events")]
+async fn events(api_data: web::Data<ApiData>) -> impl Responder {
+    const CONTENT_EVENT_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
+    const CONTENT_EVENT_KEEP_ALIVE_INTERVAL: std::time::Duration =
+        std::time::Duration::from_secs(15);
+
+    // Subscribe before obtaining the first snapshot. If a change races with that query, the
+    // receiver remains dirty and sends another snapshot rather than silently missing the change.
+    let mut content_changes = api_data.event_handler.subscribe();
+
+    let stream = async_stream::stream! {
+        let mut keep_alive = tokio::time::interval(CONTENT_EVENT_KEEP_ALIVE_INTERVAL);
+        keep_alive.tick().await;
+        loop {
+            tokio::select! {
+                changed = content_changes.changed() => {
+                    if changed.is_err() {
+                        // This is only reachable if the current channel has been closed, should not
+                        // be an error.
+                        break;
+                    }
+
+                    // Progress is persisted for every downloaded chunk. Wait briefly and mark the
+                    // newest revision as seen so a burst produces at most one snapshot per interval.
+                    tokio::time::sleep(CONTENT_EVENT_INTERVAL).await;
+                    let content = content_changes.borrow_and_update();
+
+                    match serialize_content_event(&content) {
+                        Ok(event) => yield Result::<Bytes, Infallible>::Ok(event),
+                        Err(e) => {
+                            tracing::error!("Unable to serialize content update event: {e}");
+                            break;
+                        }
+                    };
+                }
+                _ = keep_alive.tick() => {
+                    yield Ok(Bytes::from_static(b": keep-alive\n\n"));
+                }
+            }
+        }
+    };
+
+    HttpResponse::Ok()
+        .insert_header(("Cache-Control", "no-cache"))
+        .content_type("text/event-stream")
+        .streaming(stream)
 }
 
 #[tracing::instrument(

--- a/leap-server/src/api/user.rs
+++ b/leap-server/src/api/user.rs
@@ -126,6 +126,16 @@ async fn events(api_data: web::Data<ApiData>) -> impl Responder {
     let stream = async_stream::stream! {
         let mut keep_alive = tokio::time::interval(CONTENT_EVENT_KEEP_ALIVE_INTERVAL);
         keep_alive.tick().await;
+        {
+            let content = content_changes.borrow_and_update();
+            match serialize_content_event(&content) {
+                Ok(event) => yield Result::<Bytes, Infallible>::Ok(event),
+                Err(e) => {
+                    tracing::error!("Unable to serialize content update event: {e}");
+                }
+            };
+        }
+
         loop {
             tokio::select! {
                 changed = content_changes.changed() => {

--- a/leap-server/src/api/user/event_handler.rs
+++ b/leap-server/src/api/user/event_handler.rs
@@ -70,6 +70,11 @@ impl StateEventHandler {
                             };
                             // TODO: emit proper data
                             let _ = serialized_state_tx.send(Arc::new(meta));
+
+                            // Throttle the event updates to limit the notification rate to roughly
+                            // 200 ms
+                            const MAX_UPDATE_RATE: std::time::Duration = std::time::Duration::from_millis(200);
+                            tokio::time::sleep(MAX_UPDATE_RATE).await;
                         }
 
                     }

--- a/leap-server/src/api/user/event_handler.rs
+++ b/leap-server/src/api/user/event_handler.rs
@@ -1,0 +1,96 @@
+//! Handles database updates by receiving watch notifications and triggering
+//! a rebuild of the serialized state of the database.
+//!
+//! This serves as an optimization to reduce the work that is done per client
+//! connection. By keeping a up-to-date single serialized state we can simply
+//! forward the bytes to the client on every response without locking and
+//! rebuilding the state for every client request.
+
+use std::sync::Arc;
+
+use tokio::sync::Notify;
+use tokio::sync::watch;
+use tracing::Instrument as _;
+
+use leap_api::api::content::meta::get::{GroupedSection, Response as ContentMetaResponse};
+
+use crate::db;
+
+async fn content_metadata(db: &db::Database) -> db::Result<ContentMetaResponse> {
+    let sections = db
+        .current_manifest_sections()
+        .instrument(tracing::info_span!(
+            "Querying manifest information from database"
+        ))
+        .await?;
+
+    let _span =
+        tracing::info_span!("Collecting manifest information as content metadata").entered();
+    let videos = sections
+        .into_iter()
+        .map(|(name, content)| {
+            let content = content.into_iter().map(|v| v.into()).collect();
+            GroupedSection { name, content }
+        })
+        .collect();
+
+    Ok(ContentMetaResponse { videos })
+}
+
+pub struct StateEventHandler {
+    task_cancel: Arc<Notify>,
+    serialized_state_tx: watch::Sender<Arc<ContentMetaResponse>>,
+}
+
+impl StateEventHandler {
+    pub async fn start(
+        state_changed_notifier: Arc<Notify>,
+        db: Arc<db::Database>,
+    ) -> db::Result<Self> {
+        let response = content_metadata(&db).await?;
+        let (serialized_state_tx, _) = watch::channel(Arc::new(response));
+        let task_cancel = Arc::new(Notify::new());
+        tokio::spawn({
+            let task_cancel = Arc::clone(&task_cancel);
+            let serialized_state_tx = serialized_state_tx.clone();
+            async move {
+                loop {
+                    tokio::select! {
+                        biased;
+                        _ = task_cancel.notified() => {
+                            return
+                        }
+                        _ = state_changed_notifier.notified() =>  {
+                            let meta = match content_metadata(&db).await {
+                                Ok(meta) => meta,
+                                Err(db_error) => {
+                                    tracing::error!("Unable to emit state update due to db error: {db_error}");
+                                    continue;
+                                }
+                            };
+                            // TODO: emit proper data
+                            let _ = serialized_state_tx.send(Arc::new(meta));
+                        }
+
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            task_cancel,
+            serialized_state_tx,
+        })
+    }
+
+    /// Creates a new receiver for the content metadata response.
+    pub fn subscribe(&self) -> watch::Receiver<Arc<ContentMetaResponse>> {
+        self.serialized_state_tx.subscribe()
+    }
+}
+
+impl Drop for StateEventHandler {
+    fn drop(&mut self) {
+        self.task_cancel.notify_one();
+    }
+}

--- a/leap-server/src/api/user/event_handler.rs
+++ b/leap-server/src/api/user/event_handler.rs
@@ -2,40 +2,19 @@
 //! a rebuild of the serialized state of the database.
 //!
 //! This serves as an optimization to reduce the work that is done per client
-//! connection. By keeping a up-to-date single serialized state we can simply
-//! forward the bytes to the client on every response without locking and
-//! rebuilding the state for every client request.
+//! connection. By keeping a up-to-date single state we can simply forward the
+//! response to the client without locking and rebuilding the state for every
+//! client request.
 
 use std::sync::Arc;
 
 use tokio::sync::Notify;
 use tokio::sync::watch;
-use tracing::Instrument as _;
 
-use leap_api::api::content::meta::get::{GroupedSection, Response as ContentMetaResponse};
+use leap_api::api::content::meta::get::Response as ContentMetaResponse;
 
+use super::utils::content_metadata;
 use crate::db;
-
-async fn content_metadata(db: &db::Database) -> db::Result<ContentMetaResponse> {
-    let sections = db
-        .current_manifest_sections()
-        .instrument(tracing::info_span!(
-            "Querying manifest information from database"
-        ))
-        .await?;
-
-    let _span =
-        tracing::info_span!("Collecting manifest information as content metadata").entered();
-    let videos = sections
-        .into_iter()
-        .map(|(name, content)| {
-            let content = content.into_iter().map(|v| v.into()).collect();
-            GroupedSection { name, content }
-        })
-        .collect();
-
-    Ok(ContentMetaResponse { videos })
-}
 
 pub struct StateEventHandler {
     task_cancel: Arc<Notify>,
@@ -65,11 +44,12 @@ impl StateEventHandler {
                                 Ok(meta) => meta,
                                 Err(db_error) => {
                                     tracing::error!("Unable to emit state update due to db error: {db_error}");
+                                    // Self-notify to try again
+                                    state_changed_notifier.notify_one();
                                     continue;
                                 }
                             };
-                            // TODO: emit proper data
-                            let _ = serialized_state_tx.send(Arc::new(meta));
+                            let _ = serialized_state_tx.send_replace(Arc::new(meta));
 
                             // Throttle the event updates to limit the notification rate to roughly
                             // 200 ms

--- a/leap-server/src/api/user/utils.rs
+++ b/leap-server/src/api/user/utils.rs
@@ -1,0 +1,36 @@
+//! Utility functions for the leap user API
+
+use tracing::Instrument as _;
+
+use leap_api::api::content::meta::get::{
+    GroupedSection, ManifestMeta, Response as ContentMetaResponse,
+};
+
+use crate::db;
+
+pub async fn content_metadata(db: &db::Database) -> db::Result<ContentMetaResponse> {
+    let meta = db
+        .current_manifest_meta()
+        .instrument(tracing::info_span!(
+            "Querying manifest information from database"
+        ))
+        .await?;
+
+    let _span =
+        tracing::info_span!("Collecting manifest information as content metadata").entered();
+
+    let meta = meta.map(|meta| ManifestMeta {
+        name: meta.name,
+        date: meta.date,
+        content: meta
+            .sections
+            .into_iter()
+            .map(|(name, content)| {
+                let content = content.into_iter().map(|v| v.into()).collect();
+                GroupedSection { name, content }
+            })
+            .collect(),
+    });
+
+    Ok(ContentMetaResponse { meta })
+}

--- a/leap-server/src/db.rs
+++ b/leap-server/src/db.rs
@@ -20,7 +20,7 @@ pub use models::{DownloadStatus, Video};
 use deadpool_diesel::{Manager, Pool};
 use diesel::{connection::SimpleConnection, prelude::*};
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
-use tokio::sync::RwLock;
+use tokio::sync::{Notify, RwLock};
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
 
@@ -67,6 +67,7 @@ pub struct Database {
     pool: Pool<Manager<diesel::sqlite::SqliteConnection>>,
     // An in-memory copy of the manifest, for fast access to the data.
     current_manifest: Arc<RwLock<Option<ManifestFile>>>,
+    update_notifier: Arc<Notify>,
 }
 
 impl Database {
@@ -101,12 +102,23 @@ impl Database {
                 .ok()
                 .and_then(|content| serde_json::from_slice(&content).ok()),
         ));
+        let update_notifier = Arc::new(Notify::new());
 
         Ok(Self {
             config,
             pool,
             current_manifest,
+            update_notifier,
         })
+    }
+
+    /// Subscribes to changes to content metadata.
+    pub fn notifier(&self) -> Arc<Notify> {
+        Arc::clone(&self.update_notifier)
+    }
+
+    fn notify_content_changed(&self) {
+        self.update_notifier.notify_one();
     }
 
     /// The database may not yet exist on disk, or may have a format from previous versions of this
@@ -161,6 +173,8 @@ impl Database {
             .write()
             .await
             .replace(manifest_data.clone());
+
+        self.notify_content_changed();
     }
 
     /// Returns a the current manifest. The manifest will not be written until all read handles are
@@ -323,6 +337,9 @@ impl Database {
             })
             .await
             .expect("Unexpected panic of a background DB thread")
+            .inspect(|_| {
+                self.notify_content_changed();
+            })
     }
 
     /// Updates the download progress for a given video. `downloaded_size` should be
@@ -347,6 +364,9 @@ impl Database {
             })
             .await
             .expect("Unexpected panic of a background DB thread")
+            .inspect(|_| {
+                self.notify_content_changed();
+            })
     }
 
     /// Marks the given video as failed with the given error message.
@@ -368,6 +388,9 @@ impl Database {
             })
             .await
             .expect("Unexpected panic of a background DB thread")
+            .inspect(|_| {
+                self.notify_content_changed();
+            })
     }
 
     /// Marks the given video as downloaded, at the given file path.
@@ -391,6 +414,9 @@ impl Database {
             })
             .await
             .expect("Unexpected panic of a background DB thread")
+            .inspect(|_| {
+                self.notify_content_changed();
+            })
     }
 }
 

--- a/leap-server/src/db.rs
+++ b/leap-server/src/db.rs
@@ -61,6 +61,13 @@ pub enum Error {
 
 pub type Result<T> = core::result::Result<T, Error>;
 
+#[derive(Clone, Debug)]
+pub struct ManifestMetadata {
+    pub name: String,
+    pub date: chrono::NaiveDate,
+    pub sections: Vec<(String, Vec<Video>)>,
+}
+
 /// The main entry point for interacting with the database and manifest.
 pub struct Database {
     config: DbConfig,
@@ -190,19 +197,20 @@ impl Database {
 
     /// Returns the current manifest content divided by sections and ordered in the same way as the
     /// manifest (for both the sections and the videos within a section).
-    pub async fn current_manifest_sections(&self) -> Result<Vec<(String, Vec<Video>)>> {
-        let manifest_sections = self
-            .current_manifest
-            .read()
-            .await
-            .as_ref()
-            .map(|manifest| manifest.sections.clone())
-            .unwrap_or(vec![]);
+    pub async fn current_manifest_meta(&self) -> Result<Option<ManifestMetadata>> {
+        let manifest_lock = self.current_manifest.read().await;
+        let Some(manifest) = manifest_lock.as_ref() else {
+            return Ok(None);
+        };
+        let name = manifest.name.clone();
+        let date = manifest.date;
 
+        let manifest_sections = manifest.sections.clone();
         let ids: Vec<String> = manifest_sections
             .iter()
             .flat_map(|s| s.content.iter().map(|v| v.id.to_string()))
             .collect();
+        drop(manifest_lock);
 
         let connection = self.pool.get().await?;
         let videos_from_db: Vec<Video> = connection
@@ -217,7 +225,7 @@ impl Database {
             .await
             .expect("Unexpected panic of a background DB thread")?;
 
-        manifest_sections
+        let manifest_sections: Result<Vec<(String, Vec<Video>)>> = manifest_sections
             .into_iter()
             .map(|s| {
                 s.content
@@ -235,7 +243,13 @@ impl Database {
                     .collect::<Result<Vec<Video>>>()
                     .map(|inner| (s.name, inner))
             })
-            .collect()
+            .collect();
+
+        Ok(Some(ManifestMetadata {
+            name,
+            date,
+            sections: manifest_sections?,
+        }))
     }
 
     /// Returns a list of all the videos in the database.
@@ -719,8 +733,20 @@ mod test {
                 .or_fail()?;
         }
 
-        let sections = db.current_manifest_sections().await.or_fail()?;
+        let meta = db.current_manifest_meta().await.or_fail()?;
 
+        assert_that!(
+            meta,
+            some(all!(
+                field!(ManifestMetadata.name, eq("manifest")),
+                field!(
+                    &ManifestMetadata.date,
+                    eq(chrono::NaiveDate::from_str("2025-10-10").unwrap())
+                )
+            ))
+        );
+
+        let sections = meta.unwrap().sections;
         assert_that!(sections.len(), eq(manifest.sections.len()));
         for ((name, content), manifest_section) in sections.iter().zip(manifest.sections) {
             expect_that!(name, eq(&manifest_section.name));

--- a/leap-server/src/lib.rs
+++ b/leap-server/src/lib.rs
@@ -140,11 +140,9 @@ pub async fn run_app(listener: TcpListener, config: LeapConfig) -> anyhow::Resul
         user_command_receiver,
     );
 
-    let api_data = web::Data::new(api::ApiData::new(
-        config.clone(),
-        Arc::clone(&database),
-        user_command_sender,
-    ));
+    let api_data = web::Data::new(
+        api::ApiData::new(config.clone(), Arc::clone(&database), user_command_sender).await,
+    );
 
     let server = HttpServer::new(move || {
         App::new()

--- a/leap-site/Cargo.toml
+++ b/leap-site/Cargo.toml
@@ -18,6 +18,6 @@ serde_json.workspace = true
 wasm-bindgen-futures.workspace = true
 wasm-bindgen.workspace = true
 wasm-logger.workspace = true
-web-sys.workspace = true
+web-sys = { workspace = true, features = ["EventSource", "MessageEvent"] }
 yew-router.workspace = true
 yew.workspace = true

--- a/leap-site/src/context.rs
+++ b/leap-site/src/context.rs
@@ -28,22 +28,24 @@
 //! ```
 
 use std::rc::Rc;
-use wasm_bindgen::{closure::Closure, JsCast};
+use wasm_bindgen::{JsCast, closure::Closure};
 use yew::prelude::*;
 
-use leap_api::api::content::meta::get::{GroupedSection, Response};
+use leap_api::{api::content::meta::get::Response, types::ManifestMeta};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ContentContext {
-    pub sections: Option<Rc<Vec<GroupedSection>>>,
+    pub loaded: bool,
+    pub manifest_meta: Rc<Option<ManifestMeta>>,
 }
 
 impl Reducible for ContentContext {
-    type Action = Vec<GroupedSection>;
+    type Action = Option<ManifestMeta>;
 
     fn reduce(self: Rc<Self>, action: Self::Action) -> Rc<Self> {
         Rc::new(Self {
-            sections: Some(Rc::new(action)),
+            loaded: true,
+            manifest_meta: Rc::new(action),
         })
     }
 }
@@ -58,7 +60,10 @@ pub struct ContentProviderProps {
 
 #[function_component(ContentProvider)]
 pub fn content_provider(props: &ContentProviderProps) -> Html {
-    let context = use_reducer(|| ContentContext { sections: None });
+    let context = use_reducer(|| ContentContext {
+        loaded: false,
+        manifest_meta: Rc::new(None),
+    });
 
     {
         let context = context.clone();
@@ -72,7 +77,7 @@ pub fn content_provider(props: &ContentProviderProps) -> Html {
                                 return;
                             };
                             match serde_json::from_str::<Response>(&data) {
-                                Ok(response) => context.dispatch(response.videos),
+                                Ok(response) => context.dispatch(response.meta),
                                 Err(e) => log::error!("Failed to decode content event: {e:?}"),
                             }
                         });

--- a/leap-site/src/context.rs
+++ b/leap-site/src/context.rs
@@ -27,9 +27,8 @@
 //! }
 //! ```
 
-use gloo_net::http::Request;
 use std::rc::Rc;
-use wasm_bindgen_futures::spawn_local;
+use wasm_bindgen::{closure::Closure, JsCast};
 use yew::prelude::*;
 
 use leap_api::api::content::meta::get::{GroupedSection, Response};
@@ -64,15 +63,35 @@ pub fn content_provider(props: &ContentProviderProps) -> Html {
     {
         let context = context.clone();
         use_effect_with((), move |_| {
-            if context.sections.is_none() {
-                let context = context.clone();
-                spawn_local(async move {
-                    if let Some(sections) = fetch_sections().await {
-                        context.dispatch(sections);
-                    }
-                });
+            let subscription = match web_sys::EventSource::new("/api/content/events") {
+                Ok(event_source) => {
+                    let on_message: Closure<dyn FnMut(web_sys::MessageEvent)> =
+                        Closure::new(move |event: web_sys::MessageEvent| {
+                            let Some(data) = event.data().as_string() else {
+                                log::error!("Content event did not contain text data");
+                                return;
+                            };
+                            match serde_json::from_str::<Response>(&data) {
+                                Ok(response) => context.dispatch(response.videos),
+                                Err(e) => log::error!("Failed to decode content event: {e:?}"),
+                            }
+                        });
+                    event_source.set_onmessage(Some(on_message.as_ref().unchecked_ref()));
+                    Some((event_source, on_message))
+                }
+                Err(e) => {
+                    log::error!("Failed to subscribe to content events: {e:?}");
+                    None
+                }
+            };
+
+            move || {
+                if let Some((event_source, on_message)) = subscription {
+                    event_source.set_onmessage(None);
+                    event_source.close();
+                    drop(on_message);
+                }
             }
-            || ()
         });
     }
 
@@ -81,24 +100,4 @@ pub fn content_provider(props: &ContentProviderProps) -> Html {
             { props.children.clone() }
         </ContextProvider<ContentContextHandle>>
     }
-}
-
-async fn fetch_sections() -> Option<Vec<GroupedSection>> {
-    let response = match Request::get("/api/content/meta").send().await {
-        Ok(v) => v,
-        Err(e) => {
-            log::error!("Failed to fetch content meta. Error performing HTTP request: {e:?}");
-            return None;
-        }
-    };
-
-    let response = match response.json::<Response>().await {
-        Ok(v) => v,
-        Err(e) => {
-            log::error!("Failed to fetch videos. Error decoding json: {e:?}");
-            return None;
-        }
-    };
-
-    Some(response.videos)
 }

--- a/leap-site/src/pages/dashboard.rs
+++ b/leap-site/src/pages/dashboard.rs
@@ -3,7 +3,10 @@
 //! It displays a list of available playlists using [`PlaylistsList`], which in turn
 //! uses [`PlaylistCard`] to render each individual playlist.
 
-use std::hash::{DefaultHasher, Hasher};
+use std::{
+    hash::{DefaultHasher, Hasher},
+    ops::Deref,
+};
 use yew::prelude::*;
 use yew_router::prelude::*;
 
@@ -59,27 +62,27 @@ pub fn playlist_card(
 pub fn playlists_list() -> Html {
     let context = use_context::<ContentContextHandle>().expect("ContentContext not found");
 
-    let Some(sections) = &context.sections else {
+    if !context.loaded {
         return html! {
             <p>{"Loading..."}</p>
         };
+    }
+
+    let Some(meta) = context.manifest_meta.deref() else {
+        return html! {
+            <p1>{ "No playlists available yet." }</p1>
+        };
     };
 
-    if sections.is_empty() {
-        html! {
-            <p1>{ "No playlists available yet." }</p1>
-        }
-    } else {
-        html! {
-                <div class="playlist-list list">
-                {
-                    sections.iter().enumerate().map(|(index, section)| {
-                        let num_videos = section.content.len();
-                        html! { <PlaylistCard playlist_id={index} playlist_name={section.name.clone()} num_videos={num_videos} /> }
-                    }).collect::<Html>()
-                }
-                </div>
-        }
+    html! {
+            <div class="playlist-list list">
+            {
+                meta.content.iter().enumerate().map(|(index, section)| {
+                    let num_videos = section.content.len();
+                    html! { <PlaylistCard playlist_id={index} playlist_name={section.name.clone()} num_videos={num_videos} /> }
+                }).collect::<Html>()
+            }
+            </div>
     }
 }
 

--- a/leap-site/src/pages/player.rs
+++ b/leap-site/src/pages/player.rs
@@ -40,33 +40,21 @@ pub fn video_player(
                             .any(|v| v.id == *video_id && v.status == Downloaded)
                     })
                 {
-                    let playlist_id = *playlist_id;
                     let video_id = video_id.clone();
-                    let context = context.clone();
 
                     spawn_local(async move {
                         let Ok(resp) = Request::post(&format!("/api/content/{video_id}/view"))
                             .send()
                             .await
+                            .inspect_err(|e| {
+                                log::error!("Failed to increment view count: {e}");
+                            })
                         else {
                             return;
                         };
 
                         if !resp.ok() {
-                            return;
-                        }
-
-                        let Some(sections) = context.sections.as_ref() else {
-                            return;
-                        };
-
-                        let mut new_sections = (**sections).clone();
-                        if let Some(video) = new_sections
-                            .get_mut(playlist_id)
-                            .and_then(|s| s.content.iter_mut().find(|v| v.id == video_id))
-                        {
-                            video.view_count += 1;
-                            context.dispatch(new_sections);
+                            log::error!("Failed to increment view count: HTTP {}", resp.status());
                         }
                     });
                 }

--- a/leap-site/src/pages/player.rs
+++ b/leap-site/src/pages/player.rs
@@ -5,7 +5,11 @@
 
 use crate::context::ContentContextHandle;
 use gloo_net::http::Request;
-use leap_api::api::content::meta::get::VideoStatus::{Downloaded, Downloading, Failed, Pending};
+use leap_api::{
+    api::content::meta::get::VideoStatus::{Downloaded, Downloading, Failed, Pending},
+    types::ManifestMeta,
+};
+use std::borrow::Borrow as _;
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
 use yew_router::prelude::*;
@@ -28,11 +32,11 @@ pub fn video_player(
 
     {
         let context = context.clone();
-        let sections_loaded = context.sections.is_some();
         use_effect_with(
-            (*playlist_id, video_id.clone(), sections_loaded),
+            (*playlist_id, video_id.clone(), context.loaded),
             move |(playlist_id, video_id, _)| {
-                if let Some(sections) = &context.sections
+                let meta: &Option<ManifestMeta> = context.manifest_meta.borrow();
+                if let Some(sections) = meta.as_ref().map(|d| &d.content)
                     && let Some(video_id) = video_id.as_ref()
                     && sections.get(*playlist_id).is_some_and(|s| {
                         s.content
@@ -63,15 +67,23 @@ pub fn video_player(
         );
     }
 
-    let Some(sections) = &context.sections else {
+    if !context.loaded {
         return html! {
             <div class={"page"}>
                 <p>{"Loading..."}</p>
             </div>
         };
+    }
+
+    let Some(meta) = context.manifest_meta.as_ref() else {
+        return html! {
+            <div class={"page"}>
+                <p>{"Video not found."}</p>
+            </div>
+        };
     };
 
-    let Some(section) = sections.get(*playlist_id) else {
+    let Some(section) = meta.content.get(*playlist_id) else {
         return html! {
             <div class={"page"}>
                 <p>{"Invalid playlist."}</p>

--- a/leap-site/src/pages/status.rs
+++ b/leap-site/src/pages/status.rs
@@ -117,12 +117,12 @@ impl<'de> serde::Deserialize<'de> for LogEntry {
 struct Status {
     version: BuildInfo,
     logs: Vec<LogEntry>,
-    manifest: Option<(String, ManifestInfo)>,
+    manifest: Option<ManifestInfo>,
 }
 
 #[derive(Properties, PartialEq)]
 pub struct ManifestStatusProps {
-    pub manifest: Option<(String, ManifestInfo)>,
+    pub manifest: Option<ManifestInfo>,
     pub on_fetch: Callback<MouseEvent>,
 }
 
@@ -135,7 +135,7 @@ pub fn manifest_status(ManifestStatusProps { manifest, on_fetch }: &ManifestStat
             <div class="card details-card">
                 <div class="details">
                 {
-                    if let Some((_, manifest_info)) = manifest {
+                    if let Some(manifest_info) = manifest {
                         html! {
                             <>
                             <div class="row">
@@ -283,7 +283,7 @@ async fn fetch_logs() -> anyhow::Result<Vec<LogEntry>> {
     Ok(new_logs)
 }
 
-async fn fetch_manifest_info() -> anyhow::Result<Option<(String, ManifestInfo)>> {
+async fn fetch_manifest_info() -> anyhow::Result<Option<ManifestInfo>> {
     let resp = Request::get("/api/manifest/latest").send().await?;
 
     if !resp.ok() {
@@ -295,7 +295,7 @@ async fn fetch_manifest_info() -> anyhow::Result<Option<(String, ManifestInfo)>>
         return Ok(None);
     }
     let info = serde_json::from_str(&text)?;
-    Ok(Some((text, info)))
+    Ok(Some(info))
 }
 
 async fn trigger_manifest_update_check() -> anyhow::Result<()> {

--- a/leap-site/src/pages/status.rs
+++ b/leap-site/src/pages/status.rs
@@ -118,7 +118,6 @@ struct Status {
     version: BuildInfo,
     logs: Vec<LogEntry>,
     manifest: Option<(String, ManifestInfo)>,
-    pending_downloads: Vec<DownloadItem>,
 }
 
 #[derive(Properties, PartialEq)]
@@ -379,9 +378,7 @@ pub fn status_dashboard() -> Html {
         let state_data = state_data.clone();
         move |_| {
             spawn_local(async move {
-                if let Some(sections) = context.sections.as_ref()
-                    && state_data.is_none()
-                {
+                if context.sections.is_some() && state_data.is_none() {
                     let version = match fetch_version_info().await {
                         Ok(logs) => logs,
                         Err(e) => {
@@ -412,27 +409,28 @@ pub fn status_dashboard() -> Html {
                         }
                     };
 
-                    let pending_downloads = sections
-                        .iter()
-                        .flat_map(|s| &s.content)
-                        .filter(|v| v.status != VideoStatus::Downloaded)
-                        .map(|v| DownloadItem {
-                            name: v.name.clone(),
-                            id: v.id.clone(),
-                            status: v.status.clone(),
-                        })
-                        .collect();
-
                     state_data.set(Some(Status {
                         version,
                         logs,
                         manifest,
-                        pending_downloads,
                     }));
                 }
             });
         }
     });
+
+    let pending_downloads: Vec<_> = context
+        .sections
+        .iter()
+        .flat_map(|s| s.iter())
+        .flat_map(|s| &s.content)
+        .filter(|v| v.status != VideoStatus::Downloaded)
+        .map(|v| DownloadItem {
+            name: v.name.clone(),
+            id: v.id.clone(),
+            status: v.status.clone(),
+        })
+        .collect();
 
     let on_fetch = Callback::from(|_| {
         web_sys::console::log_1(&"Triggering manifest fetch...".into());
@@ -455,7 +453,7 @@ pub fn status_dashboard() -> Html {
                         html! {
                             <>
                                 <ManifestStatus manifest={state_data.manifest.clone()} on_fetch={on_fetch} />
-                                <DownloadsList downloads={state_data.pending_downloads.clone()} />
+                                <DownloadsList downloads={pending_downloads.clone()} />
                                 <VersionInfo version={state_data.version.clone()} />
                                 <LogViewer logs={state_data.logs.clone()} />
                             </>

--- a/leap-site/src/pages/status.rs
+++ b/leap-site/src/pages/status.rs
@@ -10,9 +10,12 @@ use crate::context::ContentContextHandle;
 
 use gloo_net::http::Request;
 use leap_api::api::content::meta::get::VideoStatus;
+use leap_api::types::ManifestMeta;
+use std::borrow::Borrow as _;
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
 
+use leap_api::api::content::meta::get::GroupedSection;
 use leap_api::api::version::get::BuildInfo;
 
 #[derive(PartialEq, Clone)]
@@ -117,7 +120,6 @@ impl<'de> serde::Deserialize<'de> for LogEntry {
 struct Status {
     version: BuildInfo,
     logs: Vec<LogEntry>,
-    manifest: Option<ManifestInfo>,
 }
 
 #[derive(Properties, PartialEq)]
@@ -283,21 +285,6 @@ async fn fetch_logs() -> anyhow::Result<Vec<LogEntry>> {
     Ok(new_logs)
 }
 
-async fn fetch_manifest_info() -> anyhow::Result<Option<ManifestInfo>> {
-    let resp = Request::get("/api/manifest/latest").send().await?;
-
-    if !resp.ok() {
-        anyhow::bail!("Response is not successful: {}", resp.status());
-    }
-
-    let text = resp.text().await?;
-    if text.is_empty() {
-        return Ok(None);
-    }
-    let info = serde_json::from_str(&text)?;
-    Ok(Some(info))
-}
-
 async fn trigger_manifest_update_check() -> anyhow::Result<()> {
     let resp = Request::post("/api/manifest/fetch").send().await?;
     if !resp.ok() {
@@ -370,15 +357,11 @@ pub fn version_info(VersionInfoProps { version }: &VersionInfoProps) -> Html {
 pub fn status_dashboard() -> Html {
     let state_data = use_state(|| None);
 
-    let context = use_context::<ContentContextHandle>().expect("ContentContext not found");
-    let sections_loaded = context.sections.is_some();
-
-    use_effect_with(sections_loaded, {
-        let context = context.clone();
+    use_effect_with((), {
         let state_data = state_data.clone();
         move |_| {
             spawn_local(async move {
-                if context.sections.is_some() && state_data.is_none() {
+                if state_data.is_none() {
                     let version = match fetch_version_info().await {
                         Ok(logs) => logs,
                         Err(e) => {
@@ -399,30 +382,25 @@ pub fn status_dashboard() -> Html {
                         }
                     };
 
-                    let manifest = match fetch_manifest_info().await {
-                        Ok(v) => v,
-                        Err(e) => {
-                            web_sys::console::log_1(
-                                &format!("Error while fetching manifest information: {e}").into(),
-                            );
-                            return;
-                        }
-                    };
-
-                    state_data.set(Some(Status {
-                        version,
-                        logs,
-                        manifest,
-                    }));
+                    state_data.set(Some(Status { version, logs }));
                 }
             });
         }
     });
 
-    let pending_downloads: Vec<_> = context
-        .sections
+    let context = use_context::<ContentContextHandle>().expect("ContentContext not found");
+
+    let meta: &Option<ManifestMeta> = context.manifest_meta.borrow();
+    let manifest_data = meta.as_ref().map(|meta| ManifestInfo {
+        name: meta.name.clone(),
+        date: meta.date.to_string(),
+    });
+
+    let pending_downloads: Vec<_> = meta
+        .as_ref()
+        .map(|meta| &meta.content as &[GroupedSection])
+        .unwrap_or(&[])
         .iter()
-        .flat_map(|s| s.iter())
         .flat_map(|s| &s.content)
         .filter(|v| v.status != VideoStatus::Downloaded)
         .map(|v| DownloadItem {
@@ -452,7 +430,7 @@ pub fn status_dashboard() -> Html {
                     if let Some(state_data) = &*state_data {
                         html! {
                             <>
-                                <ManifestStatus manifest={state_data.manifest.clone()} on_fetch={on_fetch} />
+                                <ManifestStatus manifest={manifest_data} on_fetch={on_fetch} />
                                 <DownloadsList downloads={pending_downloads.clone()} />
                                 <VersionInfo version={state_data.version.clone()} />
                                 <LogViewer logs={state_data.logs.clone()} />


### PR DESCRIPTION
This does not address yet all the cases, but the most common ones are handled:
- Updates of the view counts should now be consistent across clients.
- Updates of the download status.
- Updates of the manifest information (name and date) on the status page.

Provisioning is not handled, as well as the log data is also not handled.

Closes #30 