### PR TITLE
Initial set of integration tests for LEAP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ video-data
 .direnv
 result
 /leap-linux/output
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,6 +1038,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "config"
 version = "0.15.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,6 +1142,16 @@ dependencies = [
  "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1689,6 +1709,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
 name = "futures-util"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1758,9 +1784,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2005,7 +2033,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "956caa58d4857bc9941749d55e4bd3000032d8212762586fa5705632967140e7"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -2301,9 +2329,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2495,6 +2525,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.20",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2595,12 +2674,16 @@ dependencies = [
  "leap-api",
  "libsqlite3-sys",
  "nix",
+ "rand",
  "regex",
+ "reqwest",
+ "rstest",
  "secrecy",
  "serde",
  "serde_json",
  "sha2 0.11.0",
  "static-files 0.3.1",
+ "temp-env",
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
@@ -2734,6 +2817,12 @@ checksum = "ff9840bcc50b71349309900da0ce7279aa336ae71d73250b07998932c7d97c25"
 dependencies = [
  "hashbrown 0.17.1",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -3133,7 +3222,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -3167,6 +3265,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.20",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3217,6 +3372,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3259,6 +3423,54 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.15",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "rfc6979"
@@ -3315,6 +3527,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.119",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3323,6 +3564,12 @@ dependencies = [
  "cfg-if",
  "ordered-multimap",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -3378,8 +3625,36 @@ version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3404,6 +3679,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -3451,7 +3735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3635,6 +3919,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3757,6 +4057,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3765,6 +4074,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]
@@ -3877,6 +4216,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -4022,6 +4376,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4042,8 +4408,31 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -4283,6 +4672,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4383,6 +4782,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4397,6 +4815,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -4444,6 +4871,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,6 +1462,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "downcast-rs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2582,6 +2588,7 @@ dependencies = [
  "deadpool-diesel",
  "diesel",
  "diesel_migrations",
+ "dotenvy",
  "googletest",
  "http 1.5.0",
  "humantime-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,13 +37,16 @@ humantime-serde = "1.1.1"
 libsqlite3-sys = { version = "0.38", features = ["bundled"] }
 log = "0.4"
 nix = { version = "0.31.2", features = ["mount", "reboot", "fs"] }
+rand = "0.10.2"
 regex = "1.12.3"
 reqwest = { version = "0.13", features = ["blocking", "json"] }
+rstest = "0.26.1"
 secrecy = { version = "0.10.3", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.11.0"
 static-files = "0.3.1"
+temp-env = "0.3.6"
 tempfile = "3.27"
 thiserror = "2.0.18"
 tokio = { version = "1.51", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ dbus = { version = "0.9.10", features = ["vendored"] }
 deadpool-diesel = { version = "0.7.0", features = ["sqlite"] }
 diesel = { version = "2.3.7", features = ["sqlite", "returning_clauses_for_sqlite_3_35"] }
 diesel_migrations = "2.3.1"
+dotenvy = "0.15.7"
 gloo-net = "0.7"
 gloo-timers = { version = "0.4", features = ["futures"] }
 googletest = "0.14"

--- a/leap-server/Cargo.toml
+++ b/leap-server/Cargo.toml
@@ -28,6 +28,7 @@ dbus = { workspace = true, optional = true }
 deadpool-diesel.workspace = true
 diesel.workspace = true
 diesel_migrations.workspace = true
+dotenvy.workspace = true
 http.workspace = true
 humantime-serde.workspace = true
 leap-api.workspace = true

--- a/leap-server/Cargo.toml
+++ b/leap-server/Cargo.toml
@@ -49,9 +49,14 @@ tracing-bunyan-formatter.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
 uuid.workspace = true
+rstest.workspace = true
 
 [dev-dependencies]
 googletest.workspace = true
+rand.workspace = true
+reqwest.workspace = true
+rstest.workspace = true
+temp-env.workspace = true
 tempfile.workspace = true
 
 [build-dependencies]

--- a/leap-server/default.nix
+++ b/leap-server/default.nix
@@ -18,6 +18,7 @@ top@{ inputs, ... }:
           };
 
           nativeBuildInputs = with pkgs; [
+            cacert # needed by the tests in this package.
             lld
           ];
 

--- a/leap-server/src/api.rs
+++ b/leap-server/src/api.rs
@@ -15,8 +15,18 @@ pub use user::ApiData;
 #[cfg(feature = "provision")]
 pub use provision::ProvisionApiData;
 
+/// Returns the current build information.
+///
+/// This endpoint provides information about the current version, git hash, and build profile.
+#[actix_web::get("/health_check")]
+async fn health_check() -> impl actix_web::Responder {
+    actix_web::HttpResponse::Ok()
+}
+
 fn common_api_handlers() -> actix_web::Scope {
-    web::scope("api").service(user::get_version)
+    web::scope("api")
+        .service(user::get_version)
+        .service(health_check)
 }
 
 /// Registers the main API handlers.

--- a/leap-server/src/cfg.rs
+++ b/leap-server/src/cfg.rs
@@ -194,7 +194,11 @@ pub fn get_config(path: &Path) -> Result<LeapConfig> {
             path.to_str()
                 .context("Parsing configuration path as a str")?,
         ))
-        .add_source(config::Environment::with_prefix("LEAP"))
+        .add_source(
+            config::Environment::with_prefix("LEAP")
+                .prefix_separator("_")
+                .separator("__"),
+        )
         .build()
         .context("Building the configuration of the LEAP from file and environment")?;
 

--- a/leap-server/src/cfg.rs
+++ b/leap-server/src/cfg.rs
@@ -74,6 +74,16 @@ pub struct RetryParams {
     pub max_backoff: std::time::Duration,
 }
 
+impl RetryParams {
+    pub fn fixed_backoff(duration: std::time::Duration) -> RetryParams {
+        RetryParams {
+            initial_backoff: duration,
+            backoff_factor: 1.0,
+            max_backoff: duration,
+        }
+    }
+}
+
 /// Configuration for the downloader.
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
 pub struct DownloaderConfig {
@@ -136,7 +146,7 @@ impl DbConfig {
 
 /// Configuration to access the S3 server. Note the bucket is handled separately in the main
 /// configuration.
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone, Default)]
 pub struct S3Config {
     /// S3 Endpoint URL. Defaults to AWS if not given.
     pub endpoint_url: Option<String>,

--- a/leap-server/src/main.rs
+++ b/leap-server/src/main.rs
@@ -101,6 +101,9 @@ async fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    // Load .env file if present
+    let _ = dotenvy::dotenv();
+
     std::cfg_select! {
         feature = "provision" => {
             if args.provision {

--- a/leap-server/tests/example_config.toml
+++ b/leap-server/tests/example_config.toml
@@ -1,0 +1,24 @@
+debug = true
+
+[db_config]
+runtime_path = "/tmp/leap/runtime_path"
+busy_timeout = "10 seconds"
+pool_size = 16
+
+[downloader_config]
+concurrent_downloads = 8
+content_path = "/tmp/leap/content_path"
+remote_server = "s3://bucket"
+update_interval = "20 seconds"
+
+[downloader_config.retry_params]
+initial_backoff = "5 seconds"
+backoff_factor = 1.5
+max_backoff = "2 hours"
+
+[s3_config]
+access_key_id = "1234"
+secret_access_key = "4567"
+endpoint_url = "https://s3.server.com"
+force_path_style = true
+region = "us-east-1"

--- a/leap-server/tests/integration/api.rs
+++ b/leap-server/tests/integration/api.rs
@@ -1,11 +1,16 @@
 use crate::utils::{TestResources, TestServer, await_video_downloads};
 
 use googletest::prelude::*;
+use leap_api::types::LocalVideoMeta;
+use leap_api::types::VideoStatus;
 use reqwest::StatusCode;
 use std::sync::LazyLock;
 use std::{str::FromStr as _, time::Duration};
 
-static TEST_SECTIONS: LazyLock<Vec<(String, Vec<(String, usize)>)>> = LazyLock::new(|| {
+type VideoDefinition = (String, usize);
+type SectionDefinition = (String, Vec<VideoDefinition>);
+
+static TEST_SECTIONS: LazyLock<Vec<SectionDefinition>> = LazyLock::new(|| {
     vec![
         (
             "Section 1".to_owned(),
@@ -17,6 +22,22 @@ static TEST_SECTIONS: LazyLock<Vec<(String, Vec<(String, usize)>)>> = LazyLock::
         (
             "Section 2".to_owned(),
             vec![("Video 3".to_owned(), 200 * 1024 + 10)],
+        ),
+    ]
+});
+
+static TEST_SECTIONS_2: LazyLock<Vec<SectionDefinition>> = LazyLock::new(|| {
+    vec![
+        (
+            "Section 3".to_owned(),
+            vec![("Video 6".to_owned(), 120 * 1024)],
+        ),
+        (
+            "Section 4".to_owned(),
+            vec![
+                ("Video 4".to_owned(), 222),
+                ("Video 5".to_owned(), 230 * 1024 + 143),
+            ],
         ),
     ]
 });
@@ -99,7 +120,7 @@ async fn manifest_and_video_fetching() -> googletest::Result<()> {
     await_video_downloads(
         &server,
         all_videos.iter().map(|(v, _)| v),
-        Duration::from_secs(5),
+        Duration::from_secs(1),
     )
     .await
     .or_fail()?;
@@ -137,7 +158,7 @@ async fn serve_video_content() -> googletest::Result<()> {
     await_video_downloads(
         &server,
         all_videos.iter().map(|(v, _)| v),
-        Duration::from_secs(5),
+        Duration::from_secs(1),
     )
     .await
     .or_fail()?;
@@ -161,6 +182,525 @@ async fn serve_video_content() -> googletest::Result<()> {
         let data = response.unwrap().bytes().await.or_fail()?;
         expect_that!(data, container_eq(expected_data));
     }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[gtest]
+async fn serve_partial_video_content() -> googletest::Result<()> {
+    leap_server::init_logging(None, false).await;
+
+    let test_resources = TestResources::try_new_for_test().or_fail()?;
+
+    // Step 1: Save videos and publish a new manifest with them
+    let all_videos = test_resources
+        .save_videos_and_publish_manifest(
+            chrono::NaiveDate::from_str("2026-08-14").or_fail()?,
+            &TEST_SECTIONS,
+        )
+        .await
+        .or_fail()?;
+
+    // Step 2: Start the LEAP server
+    let server = TestServer::start(&test_resources).or_fail()?;
+
+    // Step 3: Wait for all videos to complete downloading
+    await_video_downloads(
+        &server,
+        all_videos.iter().map(|(v, _)| v),
+        Duration::from_secs(1),
+    )
+    .await
+    .or_fail()?;
+
+    // Step 4: Get video data
+    let client = reqwest::Client::new();
+    for (video, expected_data) in all_videos {
+        let endpoint = server.endpoint_url(&format!("api/content/{}", video.id));
+        let request_builder = client.get(endpoint);
+        let start = rand::random_range(0..expected_data.len());
+        let end = rand::random_range(start..expected_data.len());
+        let request_builder = request_builder.header("Range", format!("bytes={start}-{end}"));
+        let request = request_builder.build().or_fail()?;
+        let response = client.execute(request).await;
+
+        let response_is_ok = verify_that!(
+            response,
+            ok(property!(
+                &reqwest::Response.status(),
+                eq(reqwest::StatusCode::PARTIAL_CONTENT)
+            ))
+        );
+        if response_is_ok.is_err() {
+            response_is_ok.and_log_failure();
+            continue;
+        }
+
+        let data = response.unwrap().bytes().await.or_fail()?;
+        expect_that!(data, container_eq(expected_data[start..=end].to_vec()));
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[gtest]
+async fn fetch_not_downloaded_content() -> googletest::Result<()> {
+    leap_server::init_logging(None, false).await;
+
+    let test_resources = TestResources::try_new_for_test().or_fail()?;
+
+    // Step 1: Start the LEAP server
+    let server = TestServer::start(&test_resources).or_fail()?;
+
+    // Step 2: Save videos and publish a new manifest with them
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let all_videos = test_resources
+        .save_videos_and_publish_manifest(
+            chrono::NaiveDate::from_str("2026-08-14").or_fail()?,
+            &TEST_SECTIONS,
+        )
+        .await
+        .or_fail()?;
+
+    // Step 3: Try to fetch video content
+    for (video, _) in all_videos {
+        let endpoint = server.endpoint_url(&format!("api/content/{}", video.id));
+        let response = reqwest::get(endpoint).await;
+        expect_that!(
+            response,
+            ok(property!(
+                &reqwest::Response.status(),
+                eq(reqwest::StatusCode::NOT_FOUND)
+            ))
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[gtest]
+async fn fetch_invalid_video_id() -> googletest::Result<()> {
+    leap_server::init_logging(None, false).await;
+
+    let test_resources = TestResources::try_new_for_test().or_fail()?;
+
+    // Step 1: Start the LEAP server
+    let server = TestServer::start(&test_resources).or_fail()?;
+
+    let endpoint = server.endpoint_url("api/content/1110-23");
+    let response = reqwest::get(endpoint).await;
+    expect_that!(
+        response,
+        ok(property!(
+            &reqwest::Response.status(),
+            eq(reqwest::StatusCode::BAD_REQUEST)
+        ))
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[gtest]
+async fn return_video_meta() -> googletest::Result<()> {
+    leap_server::init_logging(None, false).await;
+
+    let test_resources = TestResources::try_new_for_test().or_fail()?;
+    let manifest_date = chrono::NaiveDate::from_str("2026-08-14").or_fail()?;
+
+    // Step 1: Save videos and publish a new manifest with them
+    let all_videos = test_resources
+        .save_videos_and_publish_manifest(manifest_date, &TEST_SECTIONS)
+        .await
+        .or_fail()?;
+
+    // Step 2: Start the LEAP server
+    let server = TestServer::start(&test_resources).or_fail()?;
+
+    // Step 3: Wait for all videos to complete downloading
+    await_video_downloads(
+        &server,
+        all_videos.iter().map(|(v, _)| v),
+        Duration::from_secs(1),
+    )
+    .await
+    .or_fail()?;
+
+    // Step 4: Get meta
+    let endpoint = server.endpoint_url("api/content/meta");
+    let response = reqwest::get(endpoint).await;
+    verify_that!(
+        response,
+        ok(property!(
+            &reqwest::Response.status(),
+            eq(reqwest::StatusCode::OK)
+        ))
+    )?;
+
+    // Step 5: validate meta
+    let response: leap_api::api::content::meta::get::Response =
+        response.unwrap().json().await.or_fail()?;
+    verify_that!(response.meta, some(anything()))?;
+    let meta = response.meta.unwrap();
+    expect_eq!(meta.name, "manifest_file");
+    expect_eq!(meta.date, manifest_date);
+
+    let validate_videos = |expected_name: &str,
+                           expected_size: usize,
+                           videos: &[LocalVideoMeta]|
+     -> googletest::Result<()> {
+        let Some(vid) = videos.iter().find(|v| v.name == expected_name) else {
+            Err("Video {expected_name} not found").or_fail()?;
+            return Ok(());
+        };
+
+        verify_eq!(vid.status, VideoStatus::Downloaded)?;
+        verify_eq!(vid.size, expected_size)?;
+        verify_eq!(vid.view_count, 0)?;
+        Ok(())
+    };
+
+    let validate_section =
+        |expected_name: &str, expected_content: &[(String, usize)]| -> googletest::Result<()> {
+            //
+            let section = meta
+                .content
+                .iter()
+                .find(|section| *expected_name == section.name);
+            let Some(section) = section else {
+                Err("Section {expected_name} not found").or_fail()?;
+                return Ok(());
+            };
+
+            for (video_name, video_len) in expected_content {
+                validate_videos(video_name, *video_len, &section.content)?;
+            }
+            Ok(())
+        };
+
+    for (section_name, section_content) in &*TEST_SECTIONS {
+        validate_section(section_name, section_content).and_log_failure();
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[gtest]
+async fn return_specific_video_meta() -> googletest::Result<()> {
+    leap_server::init_logging(None, false).await;
+
+    let test_resources = TestResources::try_new_for_test().or_fail()?;
+    let manifest_date = chrono::NaiveDate::from_str("2026-08-14").or_fail()?;
+
+    // Step 1: Save videos and publish a new manifest with them
+    let all_videos = test_resources
+        .save_videos_and_publish_manifest(manifest_date, &TEST_SECTIONS)
+        .await
+        .or_fail()?;
+
+    // Step 2: Start the LEAP server
+    let server = TestServer::start(&test_resources).or_fail()?;
+
+    // Step 3: Wait for all videos to complete downloading
+    await_video_downloads(
+        &server,
+        all_videos.iter().map(|(v, _)| v),
+        Duration::from_secs(1),
+    )
+    .await
+    .or_fail()?;
+
+    for (video, data) in all_videos {
+        // Step 4: Get meta
+        let endpoint = server.endpoint_url(&format!("api/content/meta/{}", video.id));
+        let response = reqwest::get(endpoint).await;
+        verify_that!(
+            response,
+            ok(property!(
+                &reqwest::Response.status(),
+                eq(reqwest::StatusCode::OK)
+            ))
+        )?;
+
+        // Step 5: validate meta
+        let response: leap_api::api::content::meta::id::get::Response =
+            response.unwrap().json().await.or_fail()?;
+
+        verify_that!(
+            response.meta,
+            some(all!(
+                field!(LocalVideoMeta.name, eq(&video.name)),
+                field!(LocalVideoMeta.id, eq(&video.id.to_string())),
+                field!(&LocalVideoMeta.size, eq(data.len())),
+                field!(LocalVideoMeta.status, pat!(VideoStatus::Downloaded)),
+                field!(&LocalVideoMeta.view_count, eq(0)),
+            ))
+        )?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[gtest]
+async fn view_count_increments() -> googletest::Result<()> {
+    leap_server::init_logging(None, false).await;
+
+    let test_resources = TestResources::try_new_for_test().or_fail()?;
+    let manifest_date = chrono::NaiveDate::from_str("2026-08-14").or_fail()?;
+
+    // Step 1: Save videos and publish a new manifest with them
+    let all_videos = test_resources
+        .save_videos_and_publish_manifest(manifest_date, &TEST_SECTIONS)
+        .await
+        .or_fail()?;
+
+    // Step 2: Start the LEAP server
+    let server = TestServer::start(&test_resources).or_fail()?;
+
+    // Step 3: Wait for all videos to complete downloading
+    await_video_downloads(
+        &server,
+        all_videos.iter().map(|(v, _)| v),
+        Duration::from_secs(1),
+    )
+    .await
+    .or_fail()?;
+
+    let all_videos: Vec<_> = all_videos
+        .into_iter()
+        .zip([12_u64, 4, 5])
+        .map(|((video, data), count)| (video, data, count))
+        .collect();
+
+    // Step 4: Increment view counts
+    let client = reqwest::Client::new();
+    for (video, _, count) in &all_videos {
+        for _ in 0..*count {
+            let endpoint = server.endpoint_url(&format!("api/content/{}/view", video.id));
+            let request = client.post(endpoint).build().or_fail()?;
+            let response = client.execute(request).await;
+            verify_that!(
+                response,
+                ok(property!(
+                    &reqwest::Response.status(),
+                    eq(reqwest::StatusCode::OK)
+                ))
+            )?;
+        }
+    }
+
+    // Step 5: Validate view counts
+    for (video, data, expected_view_counts) in all_videos {
+        let endpoint = server.endpoint_url(&format!("api/content/meta/{}", video.id));
+        let response = reqwest::get(endpoint).await;
+        verify_that!(
+            response,
+            ok(property!(
+                &reqwest::Response.status(),
+                eq(reqwest::StatusCode::OK)
+            ))
+        )?;
+
+        let response: leap_api::api::content::meta::id::get::Response =
+            response.unwrap().json().await.or_fail()?;
+
+        verify_that!(
+            response.meta,
+            some(all!(
+                field!(LocalVideoMeta.name, eq(&video.name)),
+                field!(LocalVideoMeta.id, eq(&video.id.to_string())),
+                field!(&LocalVideoMeta.size, eq(data.len())),
+                field!(LocalVideoMeta.status, pat!(VideoStatus::Downloaded)),
+                field!(&LocalVideoMeta.view_count, eq(expected_view_counts)),
+            ))
+        )?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[gtest]
+async fn manifest_updates_after_first_sync() -> googletest::Result<()> {
+    leap_server::init_logging(None, false).await;
+
+    let test_resources = TestResources::try_new_for_test().or_fail()?;
+    let first_manifest_date = chrono::NaiveDate::from_str("2026-08-14").or_fail()?;
+
+    // Step 1: Save videos and publish a new manifest with them
+    let first_manifest_videos = test_resources
+        .save_videos_and_publish_manifest(first_manifest_date, &TEST_SECTIONS)
+        .await
+        .or_fail()?;
+
+    // Step 2: Start the LEAP server
+    let server = TestServer::start(&test_resources).or_fail()?;
+
+    // Step 3: Wait for all videos to complete downloading
+    await_video_downloads(
+        &server,
+        first_manifest_videos.iter().map(|(v, _)| v),
+        Duration::from_secs(1),
+    )
+    .await
+    .or_fail()?;
+
+    // Step 4: Set new manifest
+    let second_manifest_date = chrono::NaiveDate::from_str("2026-08-15").or_fail()?;
+    let second_manifest_videos = test_resources
+        .save_videos_and_publish_manifest(second_manifest_date, &TEST_SECTIONS_2)
+        .await
+        .or_fail()?;
+
+    // Step 5: Wait for download. Manifest is not immediately downloaded, should time out.
+    let result = await_video_downloads(
+        &server,
+        second_manifest_videos.iter().map(|(v, _)| v),
+        Duration::from_secs(1),
+    )
+    .await;
+    verify_that!(result, err(anything()))?;
+
+    // Step 6: Trigger manifest update
+    let client = reqwest::Client::new();
+    let endpoint = server.endpoint_url("api/manifest/fetch");
+    let request = client.post(endpoint).build().or_fail()?;
+    let response = client.execute(request).await;
+    verify_that!(
+        response,
+        ok(property!(
+            &reqwest::Response.status(),
+            eq(reqwest::StatusCode::OK)
+        ))
+    )?;
+
+    // Step 6: Wait for download. Now it should be successful
+    await_video_downloads(
+        &server,
+        second_manifest_videos.iter().map(|(v, _)| v),
+        Duration::from_secs(1),
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[gtest]
+async fn manifest_does_not_update_with_same_date() -> googletest::Result<()> {
+    leap_server::init_logging(None, false).await;
+
+    let test_resources = TestResources::try_new_for_test().or_fail()?;
+    let first_manifest_date = chrono::NaiveDate::from_str("2026-08-14").or_fail()?;
+
+    // Step 1: Save videos and publish a new manifest with them
+    let first_manifest_videos = test_resources
+        .save_videos_and_publish_manifest(first_manifest_date, &TEST_SECTIONS)
+        .await
+        .or_fail()?;
+
+    // Step 2: Start the LEAP server
+    let server = TestServer::start(&test_resources).or_fail()?;
+
+    // Step 3: Wait for all videos to complete downloading
+    await_video_downloads(
+        &server,
+        first_manifest_videos.iter().map(|(v, _)| v),
+        Duration::from_secs(1),
+    )
+    .await
+    .or_fail()?;
+
+    // Step 4: Set new manifest
+    let second_manifest_date = chrono::NaiveDate::from_str("2026-08-14").or_fail()?;
+    let second_manifest_videos = test_resources
+        .save_videos_and_publish_manifest(second_manifest_date, &TEST_SECTIONS_2)
+        .await
+        .or_fail()?;
+
+    // Step 5: Wait for download. Manifest is not immediately downloaded, should time out.
+    let result = await_video_downloads(
+        &server,
+        second_manifest_videos.iter().map(|(v, _)| v),
+        Duration::from_secs(1),
+    )
+    .await;
+    verify_that!(result, err(anything()))?;
+
+    // Step 6: Trigger manifest update
+    let client = reqwest::Client::new();
+    let endpoint = server.endpoint_url("api/manifest/fetch");
+    let request = client.post(endpoint).build().or_fail()?;
+    let response = client.execute(request).await;
+    verify_that!(
+        response,
+        ok(property!(
+            &reqwest::Response.status(),
+            eq(reqwest::StatusCode::OK)
+        ))
+    )?;
+
+    // Step 7: Wait for download. Manifest is not downloaded, should time out.
+    let result = await_video_downloads(
+        &server,
+        second_manifest_videos.iter().map(|(v, _)| v),
+        Duration::from_secs(1),
+    )
+    .await;
+    verify_that!(result, err(anything()))?;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[gtest]
+async fn fetch_current_manifest() -> googletest::Result<()> {
+    leap_server::init_logging(None, false).await;
+
+    let test_resources = TestResources::try_new_for_test().or_fail()?;
+    let first_manifest_date = chrono::NaiveDate::from_str("2026-08-14").or_fail()?;
+
+    // Step 1: Save videos and publish a new manifest with them
+    let first_manifest_videos = test_resources
+        .save_videos_and_publish_manifest(first_manifest_date, &TEST_SECTIONS)
+        .await
+        .or_fail()?;
+
+    // Step 2: Start the LEAP server
+    let server = TestServer::start(&test_resources).or_fail()?;
+
+    // Step 3: Wait for all videos to complete downloading
+    await_video_downloads(
+        &server,
+        first_manifest_videos.iter().map(|(v, _)| v),
+        Duration::from_secs(1),
+    )
+    .await
+    .or_fail()?;
+
+    // Step 4: Fetch manifest
+    let endpoint = server.endpoint_url("api/manifest/latest");
+    let response = reqwest::get(endpoint).await;
+    verify_that!(
+        response,
+        ok(property!(
+            &reqwest::Response.status(),
+            eq(reqwest::StatusCode::OK)
+        ))
+    )?;
+
+    // Step 5: Validate manifest
+    let manifest_received = response.unwrap().text().await;
+    let manifest_on_disk =
+        &tokio::fs::read_to_string(test_resources.file_server_path().join("manifest.json"))
+            .await
+            .or_fail()?;
+    expect_that!(&manifest_received, ok(eq(manifest_on_disk)));
 
     Ok(())
 }

--- a/leap-server/tests/integration/api.rs
+++ b/leap-server/tests/integration/api.rs
@@ -1,12 +1,32 @@
-use crate::utils::{TestResources, TestServer};
+use crate::utils::{TestResources, TestServer, await_video_downloads};
 
 use googletest::prelude::*;
 use reqwest::StatusCode;
+use std::sync::LazyLock;
+use std::{str::FromStr as _, time::Duration};
+
+static TEST_SECTIONS: LazyLock<Vec<(String, Vec<(String, usize)>)>> = LazyLock::new(|| {
+    vec![
+        (
+            "Section 1".to_owned(),
+            vec![
+                ("Video 1".to_owned(), 100),
+                ("Video 2".to_owned(), 100 * 1024),
+            ],
+        ),
+        (
+            "Section 2".to_owned(),
+            vec![("Video 3".to_owned(), 200 * 1024 + 10)],
+        ),
+    ]
+});
 
 /// Constructs the server and expects it to respond to the health_check API endpoint.
 #[tokio::test]
 #[gtest]
 async fn initialize_server() -> googletest::Result<()> {
+    leap_server::init_logging(None, false).await;
+
     let test_resources = TestResources::try_new_for_test().or_fail()?;
     let server = TestServer::start(&test_resources).or_fail()?;
 
@@ -19,10 +39,12 @@ async fn initialize_server() -> googletest::Result<()> {
     Ok(())
 }
 
-/// Constructs the server and expects it to respond to the health_check API endpoint.
+/// Queries the version information reported by the server.
 #[tokio::test]
 #[gtest]
 async fn version_endpoint() -> googletest::Result<()> {
+    leap_server::init_logging(None, false).await;
+
     let test_resources = TestResources::try_new_for_test().or_fail()?;
     let server = TestServer::start(&test_resources).or_fail()?;
 
@@ -50,6 +72,95 @@ async fn version_endpoint() -> googletest::Result<()> {
     expect_that!(version.homepage, eq(std::env!("CARGO_PKG_HOMEPAGE")));
     expect_that!(version.license, eq(std::env!("CARGO_PKG_LICENSE")));
     expect_that!(version.repository, eq(std::env!("CARGO_PKG_REPOSITORY")));
+
+    Ok(())
+}
+
+#[tokio::test]
+#[gtest]
+async fn manifest_and_video_fetching() -> googletest::Result<()> {
+    leap_server::init_logging(None, false).await;
+
+    let test_resources = TestResources::try_new_for_test().or_fail()?;
+
+    // Step 1: Save videos and publish a new manifest with them
+    let all_videos = test_resources
+        .save_videos_and_publish_manifest(
+            chrono::NaiveDate::from_str("2026-08-14").or_fail()?,
+            &TEST_SECTIONS,
+        )
+        .await
+        .or_fail()?;
+
+    // Step 2: Start the LEAP server
+    let server = TestServer::start(&test_resources).or_fail()?;
+
+    // Step 3: Wait for all videos to complete downloading
+    await_video_downloads(
+        &server,
+        all_videos.iter().map(|(v, _)| v),
+        Duration::from_secs(5),
+    )
+    .await
+    .or_fail()?;
+
+    // Step 4: Double-check they are actually downloaded
+    for (video, data) in &all_videos {
+        test_resources
+            .verify_saved_video_matches(video, data)
+            .await
+            .or_fail()?;
+    }
+    Ok(())
+}
+
+#[tokio::test]
+#[gtest]
+async fn serve_video_content() -> googletest::Result<()> {
+    leap_server::init_logging(None, false).await;
+
+    let test_resources = TestResources::try_new_for_test().or_fail()?;
+
+    // Step 1: Save videos and publish a new manifest with them
+    let all_videos = test_resources
+        .save_videos_and_publish_manifest(
+            chrono::NaiveDate::from_str("2026-08-14").or_fail()?,
+            &TEST_SECTIONS,
+        )
+        .await
+        .or_fail()?;
+
+    // Step 2: Start the LEAP server
+    let server = TestServer::start(&test_resources).or_fail()?;
+
+    // Step 3: Wait for all videos to complete downloading
+    await_video_downloads(
+        &server,
+        all_videos.iter().map(|(v, _)| v),
+        Duration::from_secs(5),
+    )
+    .await
+    .or_fail()?;
+
+    // Step 4: Get video data
+    for (video, expected_data) in all_videos {
+        let endpoint = server.endpoint_url(&format!("api/content/{}", video.id));
+        let response = reqwest::get(endpoint).await;
+        let response_is_ok = verify_that!(
+            response,
+            ok(property!(
+                &reqwest::Response.status(),
+                eq(reqwest::StatusCode::OK)
+            ))
+        );
+        if response_is_ok.is_err() {
+            response_is_ok.and_log_failure();
+            continue;
+        }
+
+        let data = response.unwrap().bytes().await.or_fail()?;
+        expect_that!(data, container_eq(expected_data));
+    }
 
     Ok(())
 }

--- a/leap-server/tests/integration/api.rs
+++ b/leap-server/tests/integration/api.rs
@@ -46,8 +46,6 @@ static TEST_SECTIONS_2: LazyLock<Vec<SectionDefinition>> = LazyLock::new(|| {
 #[tokio::test]
 #[gtest]
 async fn initialize_server() -> googletest::Result<()> {
-    leap_server::init_logging(None, false).await;
-
     let test_resources = TestResources::try_new_for_test().or_fail()?;
     let server = TestServer::start(&test_resources).or_fail()?;
 
@@ -64,8 +62,6 @@ async fn initialize_server() -> googletest::Result<()> {
 #[tokio::test]
 #[gtest]
 async fn version_endpoint() -> googletest::Result<()> {
-    leap_server::init_logging(None, false).await;
-
     let test_resources = TestResources::try_new_for_test().or_fail()?;
     let server = TestServer::start(&test_resources).or_fail()?;
 
@@ -100,8 +96,6 @@ async fn version_endpoint() -> googletest::Result<()> {
 #[tokio::test]
 #[gtest]
 async fn manifest_and_video_fetching() -> googletest::Result<()> {
-    leap_server::init_logging(None, false).await;
-
     let test_resources = TestResources::try_new_for_test().or_fail()?;
 
     // Step 1: Save videos and publish a new manifest with them
@@ -138,8 +132,6 @@ async fn manifest_and_video_fetching() -> googletest::Result<()> {
 #[tokio::test]
 #[gtest]
 async fn serve_video_content() -> googletest::Result<()> {
-    leap_server::init_logging(None, false).await;
-
     let test_resources = TestResources::try_new_for_test().or_fail()?;
 
     // Step 1: Save videos and publish a new manifest with them
@@ -189,8 +181,6 @@ async fn serve_video_content() -> googletest::Result<()> {
 #[tokio::test]
 #[gtest]
 async fn serve_partial_video_content() -> googletest::Result<()> {
-    leap_server::init_logging(None, false).await;
-
     let test_resources = TestResources::try_new_for_test().or_fail()?;
 
     // Step 1: Save videos and publish a new manifest with them
@@ -247,8 +237,6 @@ async fn serve_partial_video_content() -> googletest::Result<()> {
 #[tokio::test]
 #[gtest]
 async fn fetch_not_downloaded_content() -> googletest::Result<()> {
-    leap_server::init_logging(None, false).await;
-
     let test_resources = TestResources::try_new_for_test().or_fail()?;
 
     // Step 1: Start the LEAP server
@@ -283,8 +271,6 @@ async fn fetch_not_downloaded_content() -> googletest::Result<()> {
 #[tokio::test]
 #[gtest]
 async fn fetch_invalid_video_id() -> googletest::Result<()> {
-    leap_server::init_logging(None, false).await;
-
     let test_resources = TestResources::try_new_for_test().or_fail()?;
 
     // Step 1: Start the LEAP server
@@ -306,8 +292,6 @@ async fn fetch_invalid_video_id() -> googletest::Result<()> {
 #[tokio::test]
 #[gtest]
 async fn return_video_meta() -> googletest::Result<()> {
-    leap_server::init_logging(None, false).await;
-
     let test_resources = TestResources::try_new_for_test().or_fail()?;
     let manifest_date = chrono::NaiveDate::from_str("2026-08-14").or_fail()?;
 
@@ -391,8 +375,6 @@ async fn return_video_meta() -> googletest::Result<()> {
 #[tokio::test]
 #[gtest]
 async fn return_specific_video_meta() -> googletest::Result<()> {
-    leap_server::init_logging(None, false).await;
-
     let test_resources = TestResources::try_new_for_test().or_fail()?;
     let manifest_date = chrono::NaiveDate::from_str("2026-08-14").or_fail()?;
 
@@ -448,8 +430,6 @@ async fn return_specific_video_meta() -> googletest::Result<()> {
 #[tokio::test]
 #[gtest]
 async fn view_count_increments() -> googletest::Result<()> {
-    leap_server::init_logging(None, false).await;
-
     let test_resources = TestResources::try_new_for_test().or_fail()?;
     let manifest_date = chrono::NaiveDate::from_str("2026-08-14").or_fail()?;
 
@@ -527,8 +507,6 @@ async fn view_count_increments() -> googletest::Result<()> {
 #[tokio::test]
 #[gtest]
 async fn manifest_updates_after_first_sync() -> googletest::Result<()> {
-    leap_server::init_logging(None, false).await;
-
     let test_resources = TestResources::try_new_for_test().or_fail()?;
     let first_manifest_date = chrono::NaiveDate::from_str("2026-08-14").or_fail()?;
 
@@ -593,8 +571,6 @@ async fn manifest_updates_after_first_sync() -> googletest::Result<()> {
 #[tokio::test]
 #[gtest]
 async fn manifest_does_not_update_with_same_date() -> googletest::Result<()> {
-    leap_server::init_logging(None, false).await;
-
     let test_resources = TestResources::try_new_for_test().or_fail()?;
     let first_manifest_date = chrono::NaiveDate::from_str("2026-08-14").or_fail()?;
 
@@ -660,8 +636,6 @@ async fn manifest_does_not_update_with_same_date() -> googletest::Result<()> {
 #[tokio::test]
 #[gtest]
 async fn fetch_current_manifest() -> googletest::Result<()> {
-    leap_server::init_logging(None, false).await;
-
     let test_resources = TestResources::try_new_for_test().or_fail()?;
     let first_manifest_date = chrono::NaiveDate::from_str("2026-08-14").or_fail()?;
 

--- a/leap-server/tests/integration/api.rs
+++ b/leap-server/tests/integration/api.rs
@@ -1,0 +1,55 @@
+use crate::utils::{TestResources, TestServer};
+
+use googletest::prelude::*;
+use reqwest::StatusCode;
+
+/// Constructs the server and expects it to respond to the health_check API endpoint.
+#[tokio::test]
+#[gtest]
+async fn initialize_server() -> googletest::Result<()> {
+    let test_resources = TestResources::try_new_for_test().or_fail()?;
+    let server = TestServer::start(&test_resources).or_fail()?;
+
+    let response = reqwest::get(server.endpoint_url("api/health_check")).await;
+    expect_that!(
+        response,
+        ok(property!(&reqwest::Response.status(), eq(StatusCode::OK)))
+    );
+
+    Ok(())
+}
+
+/// Constructs the server and expects it to respond to the health_check API endpoint.
+#[tokio::test]
+#[gtest]
+async fn version_endpoint() -> googletest::Result<()> {
+    let test_resources = TestResources::try_new_for_test().or_fail()?;
+    let server = TestServer::start(&test_resources).or_fail()?;
+
+    let response = reqwest::get(server.endpoint_url("api/version")).await;
+    assert_that!(
+        response,
+        ok(all!(property!(
+            &reqwest::Response.status(),
+            eq(StatusCode::OK)
+        ),))
+    );
+
+    let version: leap_api::api::version::get::Response =
+        response.or_fail()?.json().await.or_fail()?;
+    expect_that!(version.version, eq(std::env!("CARGO_PKG_VERSION")));
+    expect_that!(version.name, eq(std::env!("CARGO_PKG_NAME")));
+    expect_that!(
+        version.authors,
+        container_eq(
+            std::env!("CARGO_PKG_AUTHORS")
+                .split(":")
+                .collect::<Vec<_>>()
+        )
+    );
+    expect_that!(version.homepage, eq(std::env!("CARGO_PKG_HOMEPAGE")));
+    expect_that!(version.license, eq(std::env!("CARGO_PKG_LICENSE")));
+    expect_that!(version.repository, eq(std::env!("CARGO_PKG_REPOSITORY")));
+
+    Ok(())
+}

--- a/leap-server/tests/integration/cfg.rs
+++ b/leap-server/tests/integration/cfg.rs
@@ -1,0 +1,187 @@
+//! Tests of the LEAP configuration module
+
+use googletest::OrFail as _;
+use googletest::prelude::*;
+use http::Uri;
+use leap_server::cfg::DbConfig;
+use leap_server::cfg::DownloaderConfig;
+use leap_server::cfg::LeapConfig;
+use leap_server::cfg::RetryParams;
+use leap_server::cfg::S3Config;
+use secrecy::ExposeSecret as _;
+use std::ffi::OsString;
+use std::sync::LazyLock;
+use std::time::Duration;
+use std::{path::PathBuf, str::FromStr as _};
+
+static EXPECTED_CONFIG: LazyLock<LeapConfig> = LazyLock::new(|| LeapConfig {
+    debug: true,
+    downloader_config: DownloaderConfig {
+        concurrent_downloads: 8,
+        content_path: PathBuf::from_str("/tmp/leap/content_path").unwrap(),
+        remote_server: Uri::from_static("s3://bucket"),
+        update_interval: Duration::from_secs(20),
+        retry_params: RetryParams {
+            initial_backoff: Duration::from_secs(5),
+            backoff_factor: 1.5,
+            max_backoff: Duration::from_hours(2),
+        },
+    },
+    db_config: DbConfig {
+        busy_timeout: Duration::from_secs(10),
+        pool_size: 16,
+        runtime_path: PathBuf::from_str("/tmp/leap/runtime_path").unwrap(),
+    },
+    s3_config: S3Config {
+        endpoint_url: Some("https://s3.server.com".to_owned()),
+        access_key_id: Some("1234".into()),
+        secret_access_key: Some("4567".into()),
+        force_path_style: true,
+        region: "us-east-1".to_owned(),
+    },
+});
+
+#[rstest::rstest]
+#[case(
+    vec![],
+    || {
+        EXPECTED_CONFIG.clone()
+    }
+)]
+#[case(
+    vec![("LEAP_DEBUG", "false")],
+    || {
+        let mut cfg = EXPECTED_CONFIG.clone();
+        cfg.debug = false;
+        cfg
+    }
+)]
+#[case(
+    vec![("LEAP_DOWNLOADER_CONFIG__CONCURRENT_DOWNLOADS", "32")],
+    || {
+        let mut cfg = EXPECTED_CONFIG.clone();
+        cfg.downloader_config.concurrent_downloads = 32;
+        cfg
+    }
+)]
+#[case(
+    vec![("LEAP_DOWNLOADER_CONFIG__CONTENT_PATH", "new_content_path")],
+    || {
+        let mut cfg = EXPECTED_CONFIG.clone();
+        cfg.downloader_config.content_path = PathBuf::from_str("new_content_path").unwrap();
+        cfg
+    }
+)]
+#[case(
+    vec![
+        ("LEAP_S3_CONFIG__ACCESS_KEY_ID", "access_key_id"),
+        ("LEAP_DB_CONFIG__BUSY_TIMEOUT", "1 sec")
+    ],
+    || {
+        let mut cfg = EXPECTED_CONFIG.clone();
+        cfg.s3_config.access_key_id = Some("access_key_id".into());
+        cfg.db_config.busy_timeout = Duration::from_secs(1);
+        cfg
+    }
+)]
+#[gtest]
+fn overrides_with_env_vars(
+    #[case] env_vars: Vec<(&str, &str)>,
+    #[case] expected_config_generator: fn() -> LeapConfig,
+) -> googletest::Result<()> {
+    let expected_config = expected_config_generator();
+    let env_vars: Vec<(OsString, Option<OsString>)> = env_vars
+        .into_iter()
+        .map(|(name, val)| (name.into(), Some(val.into())))
+        .collect();
+
+    let path = PathBuf::from_str(concat!(
+        std::env!("CARGO_MANIFEST_DIR"),
+        "/tests/example_config.toml"
+    ))
+    .or_fail()?;
+    let config = temp_env::with_vars(env_vars, || leap_server::cfg::get_config(&path)).or_fail()?;
+
+    expect_eq!(config.debug, expected_config.debug);
+    expect_eq!(
+        config.downloader_config.concurrent_downloads,
+        expected_config.downloader_config.concurrent_downloads
+    );
+    expect_eq!(
+        config.downloader_config.content_path,
+        expected_config.downloader_config.content_path
+    );
+    expect_eq!(
+        config.downloader_config.remote_server,
+        expected_config.downloader_config.remote_server
+    );
+    expect_eq!(
+        config.downloader_config.update_interval,
+        expected_config.downloader_config.update_interval
+    );
+    expect_eq!(
+        config.downloader_config.retry_params.initial_backoff,
+        expected_config
+            .downloader_config
+            .retry_params
+            .initial_backoff
+    );
+    expect_eq!(
+        config.downloader_config.retry_params.backoff_factor,
+        expected_config
+            .downloader_config
+            .retry_params
+            .backoff_factor
+    );
+    expect_eq!(
+        config.downloader_config.retry_params.max_backoff,
+        expected_config.downloader_config.retry_params.max_backoff
+    );
+
+    expect_eq!(
+        config.db_config.pool_size,
+        expected_config.db_config.pool_size
+    );
+    expect_eq!(
+        config.db_config.busy_timeout,
+        expected_config.db_config.busy_timeout
+    );
+    expect_eq!(
+        config.db_config.runtime_path,
+        expected_config.db_config.runtime_path
+    );
+
+    expect_eq!(
+        config.s3_config.endpoint_url,
+        expected_config.s3_config.endpoint_url,
+    );
+    expect_eq!(
+        config.s3_config.force_path_style,
+        expected_config.s3_config.force_path_style
+    );
+    expect_eq!(
+        config
+            .s3_config
+            .access_key_id
+            .map(|s| s.expose_secret().to_owned()),
+        expected_config
+            .s3_config
+            .access_key_id
+            .clone()
+            .map(|s| s.expose_secret().to_owned())
+    );
+    expect_eq!(
+        config
+            .s3_config
+            .secret_access_key
+            .map(|s| s.expose_secret().to_owned()),
+        expected_config
+            .s3_config
+            .secret_access_key
+            .clone()
+            .map(|s| s.expose_secret().to_owned()),
+    );
+    expect_eq!(config.s3_config.region, expected_config.s3_config.region);
+
+    Ok(())
+}

--- a/leap-server/tests/integration/main.rs
+++ b/leap-server/tests/integration/main.rs
@@ -1,0 +1,5 @@
+//! Integration test cases for the leap-server.
+
+mod api;
+mod cfg;
+mod utils;

--- a/leap-server/tests/integration/utils.rs
+++ b/leap-server/tests/integration/utils.rs
@@ -9,7 +9,12 @@ use leap_server::{
     manifest::{self},
 };
 use sha2::Digest;
-use std::{net::TcpListener, path::PathBuf, str::FromStr as _, time::Duration};
+use std::{
+    net::{SocketAddr, TcpListener},
+    path::PathBuf,
+    str::FromStr as _,
+    time::Duration,
+};
 use tokio::task::AbortHandle;
 use uuid::Uuid;
 
@@ -171,23 +176,17 @@ impl Drop for TestResources {
 pub struct TestServer<'a> {
     // Resources cannot be destroyed while the server operates.
     _test_resources: std::marker::PhantomData<&'a TestResources>,
-    port: u16,
+    local_addr: SocketAddr,
     handle: AbortHandle,
 }
 
 impl<'a> TestServer<'a> {
     pub fn start(test_resources: &'a TestResources) -> googletest::Result<Self> {
         // let's try to find a random unused port
-        let (listener, port) = {
-            loop {
-                let port: u16 = rand::random_range(30000..32000);
-                let addr = format!("localhost:{port}");
-                match TcpListener::bind(&addr) {
-                    Ok(listener) => break (listener, port),
-                    Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => {}
-                    Err(error) => return Err(error.into()),
-                }
-            }
+        let (listener, local_addr) = {
+            let listener = TcpListener::bind("localhost:0").or_fail()?;
+            let addr = listener.local_addr().or_fail()?;
+            (listener, addr)
         };
 
         let leap_config = test_resources.leap_config().or_fail()?;
@@ -195,13 +194,14 @@ impl<'a> TestServer<'a> {
         let handle = handle.abort_handle();
         Ok(Self {
             _test_resources: std::marker::PhantomData,
-            port,
+            local_addr,
             handle,
         })
     }
 
     pub fn endpoint_url(&self, path: &str) -> String {
-        format!("http://localhost:{}/{}", self.port, path)
+        let addr = self.local_addr;
+        format!("http://{addr}/{}", path)
     }
 }
 

--- a/leap-server/tests/integration/utils.rs
+++ b/leap-server/tests/integration/utils.rs
@@ -1,0 +1,110 @@
+//! Several reusable utilities for integration tests, including:
+//! - A way to construct application configuration for isolated tests with
+//!   guaranteed randomized directories.
+
+use googletest::OrFail as _;
+use http::Uri;
+use leap_server::cfg::{DbConfig, DownloaderConfig, LeapConfig, RetryParams, S3Config};
+use std::{net::TcpListener, path::PathBuf, str::FromStr as _, time::Duration};
+use tokio::task::AbortHandle;
+
+/// Constructs required filesystem resources to run an integration test.
+/// Performs cleanup of the filesystem resources on drop.
+pub struct TestResources {
+    test_path: PathBuf,
+}
+
+impl TestResources {
+    pub fn try_new_for_test() -> googletest::Result<Self> {
+        let tmp_dir = std::env::temp_dir();
+        let rand_path: String = (0..=10)
+            .into_iter()
+            .map(|_| rand::random_range('a'..='z'))
+            .collect();
+        let test_path = tmp_dir.join(rand_path);
+        let resources = Self { test_path };
+        std::fs::create_dir_all(resources.content_path()).or_fail()?;
+        std::fs::create_dir_all(resources.runtime_path()).or_fail()?;
+        std::fs::create_dir_all(resources.file_server_path()).or_fail()?;
+        Ok(resources)
+    }
+
+    pub fn content_path(&self) -> PathBuf {
+        self.test_path.join("content_path")
+    }
+
+    pub fn runtime_path(&self) -> PathBuf {
+        self.test_path.join("runtime_path")
+    }
+
+    pub fn file_server_path(&self) -> PathBuf {
+        self.test_path.join("file_server_path")
+    }
+
+    pub fn leap_config(&self) -> googletest::Result<LeapConfig> {
+        let uri = &format!("file:/{}", self.file_server_path().display());
+        Ok(LeapConfig {
+            debug: false,
+            downloader_config: DownloaderConfig {
+                concurrent_downloads: 1,
+                content_path: self.content_path(),
+                remote_server: Uri::from_str(uri).or_fail()?,
+                // By default no automatic update of the manifest, leave it up to the test to trigger
+                // updates.
+                update_interval: Duration::MAX,
+                // No retries by default.
+                retry_params: RetryParams::fixed_backoff(Duration::MAX),
+            },
+            db_config: DbConfig {
+                busy_timeout: Duration::from_secs(10),
+                pool_size: 16,
+                runtime_path: self.runtime_path(),
+            },
+            s3_config: S3Config::default(),
+        })
+    }
+}
+
+impl Drop for TestResources {
+    fn drop(&mut self) {
+        // Best effort removal
+        let _ = std::fs::remove_dir_all(&self.test_path);
+    }
+}
+
+pub struct TestServer {
+    port: u16,
+    handle: AbortHandle,
+}
+
+impl TestServer {
+    pub fn start(test_resources: &TestResources) -> googletest::Result<Self> {
+        // let's try to find a random unused port
+        let (listener, port) = {
+            loop {
+                let port: u16 = rand::random_range(30000..32000);
+                let addr = format!("localhost:{port}");
+                match TcpListener::bind(&addr) {
+                    Ok(listener) => break (listener, port),
+                    Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => {}
+                    Err(error) => return Err(error.into()),
+                }
+            }
+        };
+
+        let leap_config = test_resources.leap_config().or_fail()?;
+        let handle = tokio::spawn(leap_server::run_app(listener, leap_config));
+        let handle = handle.abort_handle();
+        Ok(Self { port, handle })
+    }
+
+    pub fn endpoint_url(&self, path: &str) -> String {
+        format!("http://localhost:{}/{}", self.port, path)
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}

--- a/leap-server/tests/integration/utils.rs
+++ b/leap-server/tests/integration/utils.rs
@@ -2,11 +2,16 @@
 //! - A way to construct application configuration for isolated tests with
 //!   guaranteed randomized directories.
 
-use googletest::OrFail as _;
+use googletest::prelude::*;
 use http::Uri;
-use leap_server::cfg::{DbConfig, DownloaderConfig, LeapConfig, RetryParams, S3Config};
+use leap_server::{
+    cfg::{DbConfig, DownloaderConfig, LeapConfig, RetryParams, S3Config},
+    manifest::{self},
+};
+use sha2::Digest;
 use std::{net::TcpListener, path::PathBuf, str::FromStr as _, time::Duration};
 use tokio::task::AbortHandle;
+use uuid::Uuid;
 
 /// Constructs required filesystem resources to run an integration test.
 /// Performs cleanup of the filesystem resources on drop.
@@ -42,7 +47,7 @@ impl TestResources {
     }
 
     pub fn leap_config(&self) -> googletest::Result<LeapConfig> {
-        let uri = &format!("file:/{}", self.file_server_path().display());
+        let uri = &format!("file://localhost{}", self.file_server_path().display());
         Ok(LeapConfig {
             debug: false,
             downloader_config: DownloaderConfig {
@@ -63,6 +68,97 @@ impl TestResources {
             s3_config: S3Config::default(),
         })
     }
+
+    pub async fn save_manifest_to_remote_server(
+        &self,
+        date: chrono::NaiveDate,
+        videos: &[(String, Vec<manifest::Video>)],
+    ) -> googletest::Result<()> {
+        let manifest = manifest::ManifestFile {
+            name: "manifest_file".to_owned(),
+            date,
+            version: manifest::Version {
+                major: 1,
+                minor: 0,
+                revision: 0,
+            },
+            sections: videos
+                .iter()
+                .map(|(name, vids)| manifest::Section {
+                    name: name.to_owned(),
+                    content: vids.clone(),
+                })
+                .collect(),
+        };
+
+        let manifest_data = serde_json::to_vec(&manifest).unwrap();
+        tokio::fs::write(self.file_server_path().join("manifest.json"), manifest_data).await?;
+        Ok(())
+    }
+
+    pub async fn save_video_file_to_remote_server(
+        &self,
+        name: &str,
+        length: usize,
+    ) -> googletest::Result<(manifest::Video, Vec<u8>)> {
+        let data: Vec<u8> = rand::random_iter().take(length).collect();
+        let id = Uuid::new_v4();
+        let file_path = self.file_server_path().join(id.to_string());
+        let uri = &format!("file://localhost/{id}");
+        let mut sha256_gen = sha2::Sha256::new();
+        sha256_gen.update(&data);
+        let sha256 = sha256_gen.finalize().to_vec();
+        let sha256 = manifest::Sha256::try_from(sha256.as_slice()).or_fail()?;
+        let video = manifest::Video {
+            id,
+            name: name.to_owned(),
+            file_size: data.len().try_into().or_fail()?,
+            uri: Uri::from_str(uri).or_fail()?,
+            sha256,
+        };
+
+        tokio::fs::write(file_path, &data).await?;
+        Ok((video, data))
+    }
+
+    /// Takes an array of sections, containing name and an array of videos, containing name and length.
+    /// Saves the videos to the remote file server and publishes a manifest with them.
+    pub async fn save_videos_and_publish_manifest(
+        &self,
+        date: chrono::NaiveDate,
+        sections: &[(String, Vec<(String, usize)>)],
+    ) -> googletest::Result<Vec<(manifest::Video, Vec<u8>)>> {
+        let mut all_videos = vec![];
+        let mut manifest_sections = vec![];
+        for (name, content) in sections {
+            let mut videos = vec![];
+            for (name, size) in content {
+                let (video, data) = self
+                    .save_video_file_to_remote_server(name, *size)
+                    .await
+                    .or_fail()?;
+                all_videos.push((video.clone(), data));
+                videos.push(video);
+            }
+            manifest_sections.push(((*name).to_owned(), videos));
+        }
+
+        self.save_manifest_to_remote_server(date, &manifest_sections)
+            .await
+            .or_fail()?;
+        Ok(all_videos)
+    }
+
+    pub async fn verify_saved_video_matches(
+        &self,
+        video: &manifest::Video,
+        expected_data: &[u8],
+    ) -> googletest::Result<()> {
+        let path = self.content_path().join(format!("{}.mp4", video.id));
+        let data = tokio::fs::read(path).await.or_fail()?;
+        verify_that!(data, container_eq(expected_data.to_vec()))?;
+        Ok(())
+    }
 }
 
 impl Drop for TestResources {
@@ -72,13 +168,15 @@ impl Drop for TestResources {
     }
 }
 
-pub struct TestServer {
+pub struct TestServer<'a> {
+    // Resources cannot be destroyed while the server operates.
+    _test_resources: std::marker::PhantomData<&'a TestResources>,
     port: u16,
     handle: AbortHandle,
 }
 
-impl TestServer {
-    pub fn start(test_resources: &TestResources) -> googletest::Result<Self> {
+impl<'a> TestServer<'a> {
+    pub fn start(test_resources: &'a TestResources) -> googletest::Result<Self> {
         // let's try to find a random unused port
         let (listener, port) = {
             loop {
@@ -95,7 +193,11 @@ impl TestServer {
         let leap_config = test_resources.leap_config().or_fail()?;
         let handle = tokio::spawn(leap_server::run_app(listener, leap_config));
         let handle = handle.abort_handle();
-        Ok(Self { port, handle })
+        Ok(Self {
+            _test_resources: std::marker::PhantomData,
+            port,
+            handle,
+        })
     }
 
     pub fn endpoint_url(&self, path: &str) -> String {
@@ -103,8 +205,51 @@ impl TestServer {
     }
 }
 
-impl Drop for TestServer {
+impl<'a> Drop for TestServer<'a> {
     fn drop(&mut self) {
         self.handle.abort();
     }
+}
+
+pub async fn await_video_downloads(
+    server: &TestServer<'_>,
+    videos: impl IntoIterator<Item = &manifest::Video> + Clone,
+    timeout: Duration,
+) -> googletest::Result<()> {
+    let url = server.endpoint_url("api/content/events");
+
+    let mut response = reqwest::get(url).await.or_fail()?;
+    let operation = async {
+        loop {
+            let chunk = response.chunk().await.or_fail()?.or_fail()?;
+            if chunk.starts_with(b"data: ") {
+                let chunk = &chunk[6..];
+                let parsed: leap_api::api::content::meta::get::Response =
+                    serde_json::from_slice(chunk).or_fail()?;
+                let Some(meta) = parsed.meta else {
+                    continue;
+                };
+
+                let content_iter = meta.content.into_iter().flat_map(|s| s.content);
+
+                let all_downloaded = videos.clone().into_iter().all(|v| {
+                    let video_id = v.id.to_string();
+                    content_iter
+                        .clone()
+                        .find(|candidate| {
+                            candidate.id == video_id
+                                && candidate.status
+                                    == leap_api::api::content::meta::get::VideoStatus::Downloaded
+                        })
+                        .is_some()
+                });
+
+                if all_downloaded {
+                    break Ok(());
+                }
+            }
+        }
+    };
+
+    tokio::time::timeout(timeout, operation).await.or_fail()?
 }


### PR DESCRIPTION
Integration tests using the public API and the file backend for leap. With this, coverage rises to about 80% for the `leap-server`, not great, but decent.

This PR also:
- Adds support for `.env` to load local overrides for the configuration.
- Adds a `health_check` api endpoint.
- Fixes handling of environment variables in the config module.