### PR TITLE
Improve CI steps with coverage collection

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,7 +42,7 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: 'Install rust-toolchain.toml'
       run: rustup toolchain install
-    - run: cargo clippy
+    - run: cargo clippy --all-features --tests -- -D warnings
 
   cargo_build:
     runs-on: ubuntu-latest
@@ -62,7 +62,8 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: 'Install rust-toolchain.toml'
       run: rustup toolchain install
-    - run: cargo test
+    - run: cargo install --locked cargo-nextest
+    - run: cargo nextest run
 
   cargo_fmt:
     runs-on: ubuntu-latest
@@ -80,4 +81,22 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: 'Install rust-toolchain.toml'
       run: rustup toolchain install
-    - run: cargo doc
+    - run: RUSTDOCFLAGS='-D warnings' cargo doc --document-private-items --all-features
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: cargo_doc
+        path: ./target/doc
+
+  cargo_coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+    - name: 'Install rust-toolchain.toml'
+      run: rustup toolchain install
+    - run: cargo install --locked cargo-llvm-cov
+    - run: cargo llvm-cov --html -p leap-server
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: coverage_report
+        path: ./target/llvm-cov/html

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.4.15",
+ "h2 0.4.18",
  "http 1.5.0",
  "hyper",
  "hyper-rustls",
@@ -2062,9 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2249,7 +2249,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.15",
+ "h2 0.4.18",
  "http 1.5.0",
  "http-body 1.1.0",
  "httparse",

--- a/deny.toml
+++ b/deny.toml
@@ -23,6 +23,7 @@ ignore = [
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
     { id = "RUSTSEC-2024-0370", reason = "There is no alternative to proc-macro-error. Yew 0.22 depends on it. At this time 0.22 is the latest version" },
     { id = "RUSTSEC-2025-0141", reason = "Yew 0.22 depends on it. At this time 0.22 is the latest version." },
+    { id = "RUSTSEC-2026-0258", reason = "Low severity, actix-web needs to update first." },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/leap-server/src/downloader/tasks.rs
+++ b/leap-server/src/downloader/tasks.rs
@@ -130,7 +130,7 @@ pub async fn mark_interrupted_downloads(
 ///
 /// This task needs to be cancel-safe, because it might get cancelled by calling code if a newer
 /// manifest is found.
-/// For references on cancellation-safety: https://sunshowers.io/posts/cancelling-async-rust/
+/// For references on cancellation-safety: <https://sunshowers.io/posts/cancelling-async-rust/>
 #[tracing::instrument(
     name = "download_manifest_task",
     skip(ctx, new_manifest),


### PR DESCRIPTION
Also:
- Make clippy warnings fail CI (we can silence them when applicable).
- Make cargo doc document private items.
- Use cargo nextest to run tests.
